### PR TITLE
Modified Sanford's system tests to test against an actual server instead of a fake socket

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -12,6 +12,7 @@ end
 Sanford.init
 
 require 'test/support/service_handlers'
+require 'test/support/simple_client'
 require 'test/support/test_helper'
 
 if defined?(Assert)

--- a/test/support/services.rb
+++ b/test/support/services.rb
@@ -11,7 +11,7 @@ class DummyHost
 
   configure do
     host    'fake.local'
-    port    8000
+    port    12000
     pid_dir '/path/to/pids'
     logger  LOGGER
   end

--- a/test/support/simple_client.rb
+++ b/test/support/simple_client.rb
@@ -1,0 +1,53 @@
+require 'sanford-protocol/test/fake_socket'
+
+class SimpleClient
+
+  def self.call_with_request(service_host, version, name, params)
+    self.new(service_host).call_with_request(version, name, params)
+  end
+
+  def self.call_with_msg_body(service_host, *args)
+    self.new(service_host).call_with_msg_body(*args)
+  end
+
+  def self.call_with_encoded_msg_body(service_host, *args)
+    self.new(service_host).call_with_encoded_msg_body(*args)
+  end
+
+  def self.call_with(service_host, bytes)
+    self.new(service_host).call(bytes)
+  end
+
+  def initialize(service_host)
+    @host, @port = service_host.hostname, service_host.port
+  end
+
+  def call_with_request(*args)
+    self.call_using_fake_socket(:with_request, *args)
+  end
+
+  def call_with_msg_body(*args)
+    self.call_using_fake_socket(:with_msg_body, *args)
+  end
+
+  def call_with_encoded_msg_body(*args)
+    self.call_using_fake_socket(:with_encoded_msg_body, *args)
+  end
+
+  def call(bytes)
+    socket = TCPSocket.new(@host, @port)
+    socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
+    connection = Sanford::Protocol::Connection.new(socket)
+    socket.send(bytes, 0)
+    Sanford::Protocol::Response.parse(connection.read)
+  ensure
+    socket.close rescue false
+  end
+
+  protected
+
+  def call_using_fake_socket(method, *args)
+    self.call(Sanford::Protocol::Test::FakeSocket.send(method, *args).in)
+  end
+
+end

--- a/test/support/test_helper.rb
+++ b/test/support/test_helper.rb
@@ -1,5 +1,5 @@
 module TestHelper
-  module_function
+  extend self
 
   def preserve_and_clear_hosts
     @previous_hosts = Sanford.config.hosts.dup
@@ -9,6 +9,24 @@ module TestHelper
   def restore_hosts
     Sanford.config.hosts = @previous_hosts
     @previous_hosts = nil
+  end
+
+  def start_server(server, &block)
+    begin
+      pid = fork do
+        trap("TERM"){ server.stop }
+        server.start
+        server.join_thread
+      end
+
+      sleep 0.3 # Give time for the socket to start listening.
+      yield
+    ensure
+      if pid
+        Process.kill("TERM", pid)
+        Process.wait(pid)
+      end
+    end
   end
 
 end

--- a/test/system/request_handling_test.rb
+++ b/test/system/request_handling_test.rb
@@ -4,31 +4,27 @@
 #
 require 'assert'
 
-require 'sanford-protocol/test/helpers'
-
 class RequestHandlingTest < Assert::Context
-  include Sanford::Protocol::Test::Helpers
+  include TestHelper
 
   desc "Sanford's handling of requests"
   setup do
     @service_host = DummyHost.new
-    @server = Sanford::Server.new(@service_host)
+    @server = Sanford::Server.new(@service_host, { :ready_timeout => 0 })
   end
 
   # Simple service test that echos back the params sent to it
   class EchoTest < RequestHandlingTest
     desc "when hitting an echo service"
-    setup do
-      @socket = self.fake_socket_with_request('v1', 'echo', 'test')
-      @server.serve(@socket)
-    end
 
     should "return a successful response and echo the params sent to it" do
-      response = self.read_written_response_from_fake_socket(@socket)
+      self.start_server(@server) do
+        response = SimpleClient.call_with_request(@service_host, 'v1', 'echo', 'test')
 
-      assert_equal 200,     response.status.code
-      assert_equal nil,     response.status.message
-      assert_equal 'test',  response.data
+        assert_equal 200,     response.status.code
+        assert_equal nil,     response.status.message
+        assert_equal 'test',  response.data
+      end
     end
   end
 
@@ -45,151 +41,134 @@ class RequestHandlingTest < Assert::Context
   # Sending the server a completely wrong stream of bytes
   class BadMessageTest < ErroringRequestTest
     desc "when sent a invalid request stream"
-    setup do
-      @socket = self.fake_socket_with(Sanford::Protocol.msg_version, "\000")
-      @server.serve(@socket)
-    end
 
     should "return a bad request response with an error message" do
-      response = self.read_written_response_from_fake_socket(@socket)
+      self.start_server(@server) do
+        bytes = [ Sanford::Protocol.msg_version, "\000" ].join
+        response = SimpleClient.call_with(@service_host, bytes)
 
-      assert_equal 400,     response.status.code
-      assert_match "size",  response.status.message
-      assert_equal nil,     response.data
+        assert_equal 400,     response.status.code
+        assert_match "size",  response.status.message
+        assert_equal nil,     response.data
+      end
     end
   end
 
   # Sending the server a protocol version that doesn't match it's version
   class WrongProtocolVersionTest < ErroringRequestTest
     desc "when sent a request with a wrong protocol version"
-    setup do
-      @socket = self.fake_socket_with_msg_body({}, nil, "\000")
-      @server.serve(@socket)
-    end
 
     should "return a bad request response with an error message" do
-      response = self.read_written_response_from_fake_socket(@socket)
+      self.start_server(@server) do
+        bytes = [ Sanford::Protocol.msg_version, "\000" ].join
+        response = SimpleClient.call_with_msg_body(@service_host, {}, nil, "\000")
 
-      assert_equal 400,                 response.status.code
-      assert_match "Protocol version",  response.status.message
-      assert_equal nil,                 response.data
+        assert_equal 400,                 response.status.code
+        assert_match "Protocol version",  response.status.message
+        assert_equal nil,                 response.data
+      end
     end
   end
 
   # Sending the server a body that it can't parse
   class BadBodyTest < ErroringRequestTest
     desc "when sent a request with an invalid body"
-    setup do
-      @socket = self.fake_socket_with_encoded_msg_body("\000\001\010\011" * 2)
-      @server.serve(@socket)
-    end
-
     should "return a bad request response with an error message" do
-      response = self.read_written_response_from_fake_socket(@socket)
+      self.start_server(@server) do
+        response = SimpleClient.call_with_encoded_msg_body(@service_host, "\000\001\010\011" * 2)
 
-      assert_equal 400,     response.status.code
-      assert_match "body",  response.status.message
-      assert_equal nil,     response.data
+        assert_equal 400,     response.status.code
+        assert_match "body",  response.status.message
+        assert_equal nil,     response.data
+      end
     end
   end
 
   class MissingServiceNameTest < ErroringRequestTest
     desc "when sent a request with no service name"
-    setup do
-      @socket = self.fake_socket_with_request('v1', nil, {})
-      @server.serve(@socket)
-    end
 
     should "return a bad request response" do
-      response = self.read_written_response_from_fake_socket(@socket)
+      self.start_server(@server) do
+        response = SimpleClient.call_with_request(@service_host, 'v1', nil, {})
 
-      assert_equal 400,       response.status.code
-      assert_match "request", response.status.message
-      assert_match "name",    response.status.message
-      assert_equal nil,       response.data
+        assert_equal 400,       response.status.code
+        assert_match "request", response.status.message
+        assert_match "name",    response.status.message
+        assert_equal nil,       response.data
+      end
     end
   end
 
   class MissingServiceVersionTest < ErroringRequestTest
     desc "when sent a request with no service version"
-    setup do
-      @socket = self.fake_socket_with_request(nil, 'what', {})
-      @server.serve(@socket)
-    end
 
     should "return a bad request response" do
-      response = self.read_written_response_from_fake_socket(@socket)
+      self.start_server(@server) do
+        response = SimpleClient.call_with_request(@service_host, nil, 'what', {})
 
-      assert_equal 400,       response.status.code
-      assert_match "request", response.status.message
-      assert_match "version", response.status.message
-      assert_equal nil,       response.data
+        assert_equal 400,       response.status.code
+        assert_match "request", response.status.message
+        assert_match "version", response.status.message
+        assert_equal nil,       response.data
+      end
     end
   end
 
   # Requesting a service that is not defined
   class NotFoundServiceTest < ErroringRequestTest
     desc "when sent a request with no matching service name"
-    setup do
-      @socket = self.fake_socket_with_request('v1', 'what', {})
-      @server.serve(@socket)
-    end
 
     should "return a bad request response" do
-      response = self.read_written_response_from_fake_socket(@socket)
+      self.start_server(@server) do
+        response = SimpleClient.call_with_request(@service_host, 'v1', 'what', {})
 
-      assert_equal 404, response.status.code
-      assert_equal nil, response.status.message
-      assert_equal nil, response.data
+        assert_equal 404, response.status.code
+        assert_equal nil, response.status.message
+        assert_equal nil, response.data
+      end
     end
   end
 
   # Hitting a service that throws an exception
   class ErrorServiceTest < ErroringRequestTest
     desc "when sent a request that errors on the server"
-    setup do
-      @socket = self.fake_socket_with_request('v1', 'bad', {})
-      @server.serve(@socket)
-    end
 
     should "return a bad request response" do
-      response = self.read_written_response_from_fake_socket(@socket)
+      self.start_server(@server) do
+        response = SimpleClient.call_with_request(@service_host, 'v1', 'bad', {})
 
-      assert_equal 500,     response.status.code
-      assert_match "error", response.status.message
-      assert_equal nil,     response.data
+        assert_equal 500,     response.status.code
+        assert_match "error", response.status.message
+        assert_equal nil,     response.data
+      end
     end
   end
 
   class HaltTest < RequestHandlingTest
     desc "when sent a request that halts"
-    setup do
-      @socket = self.fake_socket_with_request('v1', 'halt_it', {})
-      @server.serve(@socket)
-    end
 
     should "return the response that was halted" do
-      response = self.read_written_response_from_fake_socket(@socket)
+      self.start_server(@server) do
+        response = SimpleClient.call_with_request(@service_host, 'v1', 'halt_it', {})
 
-      assert_equal 728,                 response.status.code
-      assert_equal "I do what I want",  response.status.message
-      assert_equal [ 1, true, 'yes' ],  response.data
+        assert_equal 728,                 response.status.code
+        assert_equal "I do what I want",  response.status.message
+        assert_equal [ 1, true, 'yes' ],  response.data
+      end
     end
   end
 
   class AuthorizeRequestTest < RequestHandlingTest
     desc "when sent a request that halts in a callback"
-    setup do
-      @socket = self.fake_socket_with_request('v1', 'authorized', {})
-      @server.serve(@socket)
-    end
 
     should "return the response that was halted" do
-      response = self.read_written_response_from_fake_socket(@socket)
+      self.start_server(@server) do
+        response = SimpleClient.call_with_request(@service_host, 'v1', 'authorized', {})
 
-      assert_equal 401,               response.status.code
-      assert_equal "Not authorized",  response.status.message
-      assert_equal nil,               response.data
+        assert_equal 401,               response.status.code
+        assert_equal "Not authorized",  response.status.message
+        assert_equal nil,               response.data
+      end
     end
   end
 


### PR DESCRIPTION
Previously, Sanford used a fake socket to 'pretend' communicating. The problem
with this is it can hide problems with using a real TCP socket. To handle this,
Sanford's system tests now spin up an instance of a Sanford server in a forked
process and send requests to it. This allows us to test Sanford using an actual
TCP socket without to much overhead.
