### PR TITLE
Added a `params` helper to the `Sanford::ServiceHandler` mixin

### DIFF
--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -50,6 +50,10 @@ module Sanford
     def after_run
     end
 
+    def params
+      self.request.params
+    end
+
     def inspect
       reference = '0x0%x' % (self.object_id << 1)
       "#<#{self.class}:#{reference} @request=#{self.request.inspect}>"

--- a/test/support/service_handlers.rb
+++ b/test/support/service_handlers.rb
@@ -32,7 +32,7 @@ class HaltWithServiceHandler < StaticServiceHandler
   end
 
   def run!
-    self.request.params['halt_with'].tap do |halt_with|
+    params['halt_with'].tap do |halt_with|
       halt(halt_with.delete(:code), halt_with)
     end
   end

--- a/test/support/services.rb
+++ b/test/support/services.rb
@@ -30,7 +30,7 @@ class DummyHost
     include Sanford::ServiceHandler
 
     def run!
-      self.request.params
+      params
     end
 
   end
@@ -47,7 +47,7 @@ class DummyHost
     include Sanford::ServiceHandler
 
     def init!
-      @number = self.request.params['number'] || 1
+      @number = params['number'] || 1
     end
 
     def run!

--- a/test/unit/service_handler_test.rb
+++ b/test/unit/service_handler_test.rb
@@ -9,10 +9,13 @@ module Sanford::ServiceHandler
     end
     subject{ @handler }
 
-    should have_instance_methods :logger, :request, :init, :init!, :run, :run!, :halt
+    should have_instance_methods :logger, :request, :init, :init!, :run, :run!, :halt, :params
 
     should "raise a NotImplementedError if run! is not overwritten" do
       assert_raises(NotImplementedError){ subject.run! }
+    end
+    should "return the request's params with #params" do
+      assert_equal subject.request.params, subject.params
     end
   end
 


### PR DESCRIPTION
Allows easier (and more common/expected) access to the request params.

Addresses #2
