### PR TITLE
Renamed `Sanford::Host` configuration option from `hostname` to `ip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ To define a Sanford host, include the mixin `Sanford::Host` on a class and use t
 
 Within the `configure` block, a few options can be set:
 
-* `hostname` - (string) The hostname or IP address for the server to bind to; default: `'0.0.0.0'`.  # TODO: chang to `ip` to not conflict with naming host objects.
+* `ip` - (string) A hostname or IP address for the server to bind to; default: `'0.0.0.0'`.
 * `port` - (integer) The port number for the server to bind to.
 * `pid_dir` - (string) Path to the directory where you want the pid file to be written; default: `Dir.pwd`.
 * `logger`- (logger) A logger for Sanford to use when handling requests; default: `Logger.new`.
@@ -143,7 +143,7 @@ rake sanford:start   # starts the first defined host
 SANFORD_NAME=AnotherHost SANFORD_PORT=13001 rake sanford:start # choose a specific host and port to run on with ENV vars
 ```
 
-The rake tasks allow using environment variables for specifying which host to run the command against and for overriding the host's configuration. They recognize the following environment variables: `SANFORD_NAME`, `SANFORD_HOSTNAME`, and `SANFORD_PORT`.
+The rake tasks allow using environment variables for specifying which host to run the command against and for overriding the host's configuration. They recognize the following environment variables: `SANFORD_NAME`, `SANFORD_IP`, and `SANFORD_PORT`.
 
 Define a `name` on a Host to set a string name for your host that can be used to reference a host when using the rake tasks.  If no name is set, Sanford will use the host's class name.
 

--- a/lib/sanford/host.rb
+++ b/lib/sanford/host.rb
@@ -4,14 +4,14 @@
 # a service handler.
 #
 # Options:
-# * `hostname`  - The string for the hostname that the TCP Server should bind
-#                 to. This defaults to '0.0.0.0'.
-# * `port`      - The integer for the port that the TCP Server should bind to.
-#                 This isn't defaulted and must be provided.
-# * `pid_dir`   - The directory to write the PID file to. This is defaulted to
-#                 Dir.pwd.
-# * `logger`    - The logger to use if the Sanford server logs messages. This is
-#                 defaulted to an instance of Ruby's Logger.
+# * `ip`      - The string for the ip that the TCP Server should bind to. This
+#               defaults to '0.0.0.0'.
+# * `port`    - The integer for the port that the TCP Server should bind to.
+#               This isn't defaulted and must be provided.
+# * `pid_dir` - The directory to write the PID file to. This is defaulted to
+#               Dir.pwd.
+# * `logger`  - The logger to use if the Sanford server logs messages. This is
+#               defaulted to an instance of Ruby's Logger.
 #
 require 'logger'
 require 'ns-options'
@@ -36,7 +36,7 @@ module Sanford
         extend Sanford::Host::ClassMethods
 
         options :config do
-          option :hostname, String,   :default => '0.0.0.0'
+          option :ip,       String,   :default => '0.0.0.0'
           option :port,     Integer
           option :pid_dir,  Pathname, :default => Dir.pwd
           option :logger,             :default => proc{ Sanford::NullLogger.new }
@@ -62,7 +62,7 @@ module Sanford
       raise(Sanford::InvalidHostError.new(self.class)) if !self.port
     end
 
-    [ :hostname, :port, :pid_dir, :logger, :exception_handler ].each do |name|
+    [ :ip, :port, :pid_dir, :logger, :exception_handler ].each do |name|
 
       define_method(name) do
         self.config.send(name)
@@ -88,7 +88,7 @@ module Sanford
 
     def inspect
       reference = '0x0%x' % (self.object_id << 1)
-      "#<#{self.class}:#{reference} hostname=#{self.config.hostname.inspect} " \
+      "#<#{self.class}:#{reference} ip=#{self.config.ip.inspect} " \
       "port=#{self.config.port.inspect}>"
     end
 

--- a/lib/sanford/manager.rb
+++ b/lib/sanford/manager.rb
@@ -17,9 +17,9 @@ module Sanford
 
     def self.call(action, options = nil)
       options ||= {}
-      options[:name]      ||= ENV['SANFORD_HOST']
-      options[:hostname]  ||= ENV['SANFORD_IP']
-      options[:port]      ||= ENV['SANFORD_PORT']
+      options[:name]  ||= ENV['SANFORD_HOST']
+      options[:ip]    ||= ENV['SANFORD_IP']
+      options[:port]  ||= ENV['SANFORD_PORT']
 
       host_class = if (registered_name = options.delete(:name))
         Sanford.config.find_host(registered_name)
@@ -32,7 +32,7 @@ module Sanford
 
     def initialize(host_class, options = {})
       @host = host_class.new(options)
-      @process_name = [ self.host.hostname, self.host.port, self.host.name ].join('_')
+      @process_name = [ self.host.ip, self.host.port, self.host.name ].join('_')
     end
 
     def call(action)

--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -17,7 +17,7 @@ module Sanford
 
     def initialize(service_host, options = {})
       @service_host = service_host
-      super(self.service_host.hostname, self.service_host.port, options)
+      super(self.service_host.ip, self.service_host.port, options)
     end
 
     def name

--- a/test/support/services.rb
+++ b/test/support/services.rb
@@ -10,7 +10,7 @@ class DummyHost
   end
 
   configure do
-    host    'localhost'
+    ip    'localhost'
     port    12000
     pid_dir File.expand_path('../../../tmp/', __FILE__)
     logger  LOGGER

--- a/test/support/simple_client.rb
+++ b/test/support/simple_client.rb
@@ -19,7 +19,7 @@ class SimpleClient
   end
 
   def initialize(service_host)
-    @host, @port = service_host.hostname, service_host.port
+    @host, @port = service_host.ip, service_host.port
   end
 
   def call_with_request(*args)

--- a/test/system/managing_test.rb
+++ b/test/system/managing_test.rb
@@ -26,8 +26,8 @@ class ManagingTest < Assert::Context
       host = Sanford.config.hosts.first
 
       self.call_sanford_manager(:run) do
-        assert_nothing_raised{ self.open_socket(host.config.hostname, host.config.port) }
-        assert File.exists?(self.expected_pid_file(host, host.config.hostname, host.config.port))
+        assert_nothing_raised{ self.open_socket(host.config.ip, host.config.port) }
+        assert File.exists?(self.expected_pid_file(host, host.config.ip, host.config.port))
       end
     end
   end
@@ -44,8 +44,8 @@ class ManagingTest < Assert::Context
       host = Sanford.config.find_host('DummyHost')
 
       self.call_sanford_manager(:run, { :name => 'DummyHost', :port => 12345 }) do
-        assert_nothing_raised{ self.open_socket(host.config.hostname, 12345) }
-        assert File.exists?(self.expected_pid_file(host, host.config.hostname, 12345))
+        assert_nothing_raised{ self.open_socket(host.config.ip, 12345) }
+        assert File.exists?(self.expected_pid_file(host, host.config.ip, 12345))
       end
     end
   end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -10,7 +10,7 @@ module Sanford::Host
         include Sanford::Host
         name 'anonymous_host'
         configure do
-          host 'anonymous.local'
+          ip 'anonymous.local'
         end
       end
       @host = @host_class.new({ :port => 12345 })
@@ -32,7 +32,7 @@ module Sanford::Host
     end
 
     should "default it's configuration from the class and overwrite with values passed to new" do
-      assert_equal 'anonymous.local', subject.config.host
+      assert_equal 'anonymous.local', subject.config.ip
       assert_equal 12345, subject.config.port
     end
   end
@@ -44,7 +44,7 @@ module Sanford::Host
     end
     subject{ @config }
 
-    should have_instance_methods :hostname, :port, :pid_dir, :logger
+    should have_instance_methods :ip, :port, :pid_dir, :logger
   end
 
   class ClassMethodsTest < BaseTest


### PR DESCRIPTION
This removes confusion of having a host have a `host` or `hostname` option.
Naming the option to `ip` removes this confusion and makes the code and
documentation read more clearly.
