### PR TITLE
Updated the `Manager` to use a host class over it's configured name

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ The basic rake tasks are useful if your application only has one host defined an
 
 ```bash
 rake sanford:start   # starts the first defined host
-SANFORD_NAME=AnotherHost SANFORD_PORT=13001 rake sanford:start # choose a specific host and port to run on with ENV vars
+SANFORD_HOST=AnotherHost SANFORD_PORT=13001 rake sanford:start # choose a specific host and port to run on with ENV vars
 ```
 
-The rake tasks allow using environment variables for specifying which host to run the command against and for overriding the host's configuration. They recognize the following environment variables: `SANFORD_NAME`, `SANFORD_IP`, and `SANFORD_PORT`.
+The rake tasks allow using environment variables for specifying which host to run the command against and for overriding the host's configuration. They recognize the following environment variables: `SANFORD_HOST`, `SANFORD_IP`, and `SANFORD_PORT`.
 
 Define a `name` on a Host to set a string name for your host that can be used to reference a host when using the rake tasks.  If no name is set, Sanford will use the host's class name.
 

--- a/lib/sanford/config.rb
+++ b/lib/sanford/config.rb
@@ -12,8 +12,20 @@ module Sanford
     option :hosts,            Set,      :default => []
     option :services_config,  Pathname, :default => ENV['SANFORD_SERVICES_CONFIG']
 
-    def self.find_host(class_name)
+    # We want class names to take precedence over a configured name, so that if
+    # a user specifies a specific class, they always get it
+    def self.find_host(name)
+      self.find_host_by_class_name(name) || self.find_host_by_name(name)
+    end
+
+    protected
+
+    def self.find_host_by_class_name(class_name)
       self.hosts.detect{|host_class| host_class.to_s == class_name.to_s }
+    end
+
+    def self.find_host_by_name(name)
+      self.hosts.detect{|host_class| host_class.name == name.to_s }
     end
 
   end

--- a/lib/sanford/manager.rb
+++ b/lib/sanford/manager.rb
@@ -17,16 +17,16 @@ module Sanford
 
     def self.call(action, options = nil)
       options ||= {}
-      options[:name]  ||= ENV['SANFORD_HOST']
+      options[:host]  ||= ENV['SANFORD_HOST']
       options[:ip]    ||= ENV['SANFORD_IP']
       options[:port]  ||= ENV['SANFORD_PORT']
 
-      host_class = if (registered_name = options.delete(:name))
-        Sanford.config.find_host(registered_name)
+      host_class = if (host_class_or_name = options.delete(:host))
+        Sanford.config.find_host(host_class_or_name)
       else
         Sanford.config.hosts.first
       end
-      raise(Sanford::NoHostError.new(registered_name)) if !host_class
+      raise(Sanford::NoHostError.new(host_class_or_name)) if !host_class
       self.new(host_class, options).call(action)
     end
 

--- a/test/system/managing_test.rb
+++ b/test/system/managing_test.rb
@@ -43,7 +43,7 @@ class ManagingTest < Assert::Context
            "use the passed options to override it's configuration" do
       host = Sanford.config.find_host('DummyHost')
 
-      self.call_sanford_manager(:run, { :name => 'DummyHost', :port => 12345 }) do
+      self.call_sanford_manager(:run, { :host => 'DummyHost', :port => 12345 }) do
         assert_nothing_raised{ self.open_socket(host.config.ip, 12345) }
         assert File.exists?(self.expected_pid_file(host, host.config.ip, 12345))
       end
@@ -84,7 +84,7 @@ class ManagingTest < Assert::Context
 
     should "raise an exception when a service host can't be found" do
       assert_raises(Sanford::NoHostError) do
-        Sanford::Manager.call(:run, :name => 'not_a_real_host')
+        Sanford::Manager.call(:run, :host => 'not_a_real_host')
       end
     end
   end

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -1,0 +1,54 @@
+require 'assert'
+
+module Sanford::Config
+
+  class BaseTest < Assert::Context
+    desc "Sanford::Config"
+    subject{ Sanford::Config }
+
+    should have_instance_methods :hosts, :services_config, :find_host
+  end
+
+  class FindHostTest < BaseTest
+    desc "find_host"
+    setup do
+      Test::Environment.store_and_clear_hosts
+      Sanford::Config.hosts.add(NotNamedHost)
+      Sanford::Config.hosts.add(NamedHost)
+      Sanford::Config.hosts.add(BadlyNamedHost)
+    end
+    teardown do
+      Test::Environment.restore_hosts
+    end
+
+    should "allow finding hosts by their class name or configured name" do
+      assert_includes NotNamedHost, subject.hosts
+      assert_includes NamedHost,    subject.hosts
+      assert_equal NotNamedHost,  subject.find_host('NotNamedHost')
+      assert_equal NamedHost,     subject.find_host('NamedHost')
+      assert_equal NamedHost,     subject.find_host('named_host')
+    end
+    should "check class name before configured name" do
+      assert_includes BadlyNamedHost, subject.hosts
+      assert_equal NotNamedHost, subject.find_host('NotNamedHost')
+    end
+  end
+
+  # Using this syntax because these classes need to be defined as top-level
+  # constants for ease in using their class names in the tests
+
+  ::NotNamedHost = Class.new do
+    include Sanford::Host
+  end
+
+  ::NamedHost = Class.new do
+    include Sanford::Host
+    name 'named_host'
+  end
+
+  ::BadlyNamedHost = Class.new do
+    include Sanford::Host
+    name 'NotNamedHost'
+  end
+
+end


### PR DESCRIPTION
This makes sure that when a host is specified when using the manager (using
environment variables for example) that it tries to find a host by it's class
before using the configured name. This is to ensure that if a user specifies a
host class when running the rake tasks, that they always get that class.

Closes #8
