### PR TITLE
Removed all usage of response 'result', using 'data' instead

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ class MyHost::V1Services::GetUser
   include Sanford::ServiceHandler
 
   def run!
-    # process the service call and generate a result
+    # process the service call and build a response
     # the return value of this method will be used as the response data
   end
 end
@@ -105,7 +105,7 @@ In addition to these, there are some helpers methods that can be used in your `r
 
 * `request`: returns the request object the host received
 * `params`: returns the params payload from the request object
-* `halt`: stop processing and return a result with a status code and message
+* `halt`: stop processing and return response data with a status code and message
 
 ```ruby
 class MyHost::Services::GetUser

--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,9 +2,9 @@ Running benchmark report...
 
 Hitting "simple" service with {}, 10000 times
 ....................................................................................................
-Total Time:   8846.5275ms
-Average Time:    0.8846ms
-Min Time:        0.6220ms
-Max Time:       74.2781ms
+Total Time:   12733.9619ms
+Average Time:     1.2733ms
+Min Time:         0.8168ms
+Max Time:        60.1289ms
 
 Done running benchmark report

--- a/lib/sanford/connection.rb
+++ b/lib/sanford/connection.rb
@@ -35,8 +35,8 @@ module Sanford
           request = Sanford::Protocol::Request.parse(self.read)
           self.validate!(request)
           self.log_request(request)
-          status, result = self.route(request)
-          response = Sanford::Protocol::Response.new(status, result)
+          status, data = self.route(request)
+          response = Sanford::Protocol::Response.new(status, data)
         rescue Exception => exception
           handler = self.exception_handler.new(exception, self.logger)
           response = handler.response

--- a/lib/sanford/host.rb
+++ b/lib/sanford/host.rb
@@ -74,7 +74,7 @@ module Sanford
     # * We catch :halt here so that the service handler helper method `halt` can
     #   throw it and have the code jump here. If the `halt` method isn't used,
     #   the block wraps the return value of the handler's `run` method to be the
-    #   expected [ status, result ] format.
+    #   expected [ status, data ] format.
     def route(request)
       services = self.config.versioned_services[request.version] || {}
       handler_class_name = services[request.name]

--- a/test/support/services.rb
+++ b/test/support/services.rb
@@ -60,8 +60,8 @@ class DummyHost
 
     def run!
       halt 728, {
-        :message => "I do what I want",
-        :result => [ 1, true, 'yes' ]
+        :message  => "I do what I want",
+        :data     => [ 1, true, 'yes' ]
       }
     end
   end

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -97,12 +97,12 @@ module Sanford::Host
     end
     subject{ @returned }
 
-    should "have returned the result of calling the `init` and `run` method of the handler" do
+    should "have returned the data of calling the `init` and `run` method of the handler" do
       expected_status_code = 200
-      expected_result = 2 * @request.params['number']
+      expected_data = 2 * @request.params['number']
 
       assert_equal expected_status_code, subject.first
-      assert_equal expected_result, subject.last
+      assert_equal expected_data, subject.last
     end
   end
 

--- a/test/unit/service_handler_test.rb
+++ b/test/unit/service_handler_test.rb
@@ -60,28 +60,28 @@ module Sanford::ServiceHandler
     setup do
       @halt_with = { :code => :success, :message => "Just a test" }
       handler = HaltWithServiceHandler.new(@halt_with)
-      @response_status, @result = handler.run
+      @response_status, @data = handler.run
     end
 
-    should "return a response with the status passed to halt and a nil result" do
+    should "return a response with the status passed to halt and a nil data" do
       assert_equal @halt_with[:code],     @response_status.first
       assert_equal @halt_with[:message],  @response_status.last
-      assert_equal @halt_with[:result],   @result
+      assert_equal @halt_with[:data],     @data
     end
   end
 
-  class HaltWithAStatusCodeAndResultTest < BaseTest
-    desc "halt with a status code and result"
+  class HaltWithAStatusCodeAndDataTest < BaseTest
+    desc "halt with a status code and data"
     setup do
-      @halt_with = { :code => 648, :result => true }
+      @halt_with = { :code => 648, :data => true }
       handler = HaltWithServiceHandler.new(@halt_with)
-      @response_status, @result = handler.run
+      @response_status, @data = handler.run
     end
 
-    should "return a response status and result when passed a number and a result option" do
+    should "return a response status and data when passed a number and a data option" do
       assert_equal @halt_with[:code],     @response_status.first
       assert_equal @halt_with[:message],  @response_status.last
-      assert_equal @halt_with[:result],   @result
+      assert_equal @halt_with[:data],     @data
     end
   end
 
@@ -91,7 +91,7 @@ module Sanford::ServiceHandler
       @handler = ConfigurableServiceHandler.new({
         :before_run => proc{ halt 601, :message => "before_run halted" }
       })
-      @response_status, @result = @handler.run
+      @response_status, @data = @handler.run
     end
 
     should "only call 'before_run' and 'after_run'" do
@@ -105,7 +105,7 @@ module Sanford::ServiceHandler
     should "return the 'before_run' response" do
       assert_equal 601,                 @response_status.first
       assert_equal "before_run halted", @response_status.last
-      assert_equal nil,                 @result
+      assert_equal nil,                 @data
     end
   end
 
@@ -124,7 +124,7 @@ module Sanford::ServiceHandler
           :before_run => proc{ halt 601, :message => "before_run halted" },
           :after_run  => @after_run
         })
-        @response_status, @result = @handler.run
+        @response_status, @data = @handler.run
       end
 
       should "only call 'before_run' and 'after_run'" do
@@ -138,7 +138,7 @@ module Sanford::ServiceHandler
       should "return the 'after_run' response" do
         assert_equal 801,                 @response_status.first
         assert_equal "after_run halted",  @response_status.last
-        assert_equal nil,                 @result
+        assert_equal nil,                 @data
       end
     end
 
@@ -149,7 +149,7 @@ module Sanford::ServiceHandler
           :run!       => proc{ halt 601, :message => "run! halted" },
           :after_run  => @after_run
         })
-        @response_status, @result = @handler.run
+        @response_status, @data = @handler.run
       end
 
       should "call 'init!', 'run!' and the callbacks" do
@@ -163,7 +163,7 @@ module Sanford::ServiceHandler
       should "return the 'after_run' response" do
         assert_equal 801,                 @response_status.first
         assert_equal "after_run halted",  @response_status.last
-        assert_equal nil,                 @result
+        assert_equal nil,                 @data
       end
     end
 


### PR DESCRIPTION
This doesn't really modify much behavior, but just syncs up Sanford with the
naming used in Sanford-Protocol. This way they both refer to the response data
as data instead of the old result. The goal was to reduce confusion from seeing
`result` everywhere when the protocol uses `data`.

Closes #6
