### PR TITLE
Allow setting configuration options at the top-level

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@ Sanford uses [Sanford::Protocol](https://github.com/redding/sanford-protocol) to
 class MyHost
   include Sanford::Host
 
-  configure do
-    port 8000
-    pid_dir '/path/to/pids'
-  end
+  port 8000
+  pid_dir '/path/to/pids'
 
   # define some services
   version 'v1' do
@@ -37,10 +35,7 @@ end
 
 ## Hosts
 
-To define a Sanford host, include the mixin `Sanford::Host` on a class and use the DSL to configure it.
-
-
-Within the `configure` block, a few options can be set:
+To define a Sanford host, include the mixin `Sanford::Host` on a class and use the DSL to configure it. A few options can be set:
 
 * `ip` - (string) A hostname or IP address for the server to bind to; default: `'0.0.0.0'`.
 * `port` - (integer) The port number for the server to bind to.

--- a/bench/services.rb
+++ b/bench/services.rb
@@ -1,10 +1,8 @@
 class BenchHost
   include Sanford::Host
 
-  configure do |config|
-    config.port     = 12000
-    config.pid_dir  = File.expand_path("../../tmp", __FILE__)
-  end
+  port     = 12000
+  pid_dir  = File.expand_path("../../tmp", __FILE__)
 
   version 'v1' do
     service 'simple', 'BenchHost::Simple'

--- a/test/support/services.rb
+++ b/test/support/services.rb
@@ -3,18 +3,12 @@ require 'logger'
 class DummyHost
   include Sanford::Host
 
-  LOGGER = begin
-    logger = Logger.new(File.expand_path("../../../log/test.log", __FILE__))
-    logger.level = Logger::DEBUG
-    logger
-  end
+  ip      'localhost'
+  port    12000
+  pid_dir File.expand_path('../../../tmp/', __FILE__)
 
-  configure do
-    ip    'localhost'
-    port    12000
-    pid_dir File.expand_path('../../../tmp/', __FILE__)
-    logger  LOGGER
-  end
+  logger = Logger.new(File.expand_path("../../../log/test.log", __FILE__))
+  logger.level = Logger::DEBUG
 
   version 'v1' do
     service_handler_ns 'DummyHost'

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -8,10 +8,8 @@ module Sanford::Host
       Test::Environment.store_and_clear_hosts
       @host_class = Class.new do
         include Sanford::Host
-        name 'anonymous_host'
-        configure do
-          ip 'anonymous.local'
-        end
+        name  'anonymous_host'
+        ip    'anonymous.local'
       end
       @host = @host_class.new({ :port => 12345 })
     end
@@ -44,14 +42,15 @@ module Sanford::Host
     end
     subject{ @config }
 
-    should have_instance_methods :ip, :port, :pid_dir, :logger
+    should have_instance_methods :name, :ip, :port, :pid_dir, :logger
   end
 
   class ClassMethodsTest < BaseTest
     desc "class methods"
     subject{ @host_class }
 
-    should have_instance_methods :name, :config, :configure, :version
+    should have_instance_methods :config, :version
+    should have_instance_methods :name, :ip, :port, :pid_dir, :logger
 
     should "have registered the class with sanford's known hosts" do
       assert_includes subject, Sanford.config.hosts


### PR DESCRIPTION
This provides a consistent interface for defining hosts and doesn't mix some
options in a configure block and others on the class directly.

Closes #1
