### PR TITLE
Added a timeout to Sanford when waiting for a request

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in sanford.gemspec
 gemspec
 
+gem 'sanford-protocol', :git => "git://github.com/redding/sanford-protocol.git"
+
 gem 'bson_ext'
 gem 'rake',     '~>0.9.2'

--- a/lib/sanford/exception_handler.rb
+++ b/lib/sanford/exception_handler.rb
@@ -31,6 +31,8 @@ module Sanford
         [ :bad_request, self.exception.message ]
       when Sanford::NotFoundError
         [ :not_found ]
+      when Sanford::Protocol::TimeoutError
+        [ :timeout ]
       when Exception
         [ :error, "An unexpected error occurred." ]
       end

--- a/sanford.gemspec
+++ b/sanford.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("daemons",           ["~>1.1"])
   gem.add_dependency("dat-tcp",           ["~>0.1"])
-  gem.add_dependency("ns-options",        ["~>1.0.0.rc1"])
+  gem.add_dependency("ns-options",        ["~>1.0.0.rc2"])
   gem.add_dependency("sanford-protocol",  ["~>0.4"])
 
   gem.add_development_dependency("assert",        ["~>1.0"])

--- a/test/support/simple_client.rb
+++ b/test/support/simple_client.rb
@@ -18,8 +18,9 @@ class SimpleClient
     self.new(service_host).call(bytes)
   end
 
-  def initialize(service_host)
+  def initialize(service_host, options = {})
     @host, @port = service_host.ip, service_host.port
+    @delay = options[:with_delay]
   end
 
   def call_with_request(*args)
@@ -38,6 +39,7 @@ class SimpleClient
     socket = TCPSocket.new(@host, @port)
     socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
     connection = Sanford::Protocol::Connection.new(socket)
+    sleep(@delay) if @delay
     socket.send(bytes, 0)
     Sanford::Protocol::Response.parse(connection.read)
   ensure

--- a/test/system/request_handling_test.rb
+++ b/test/system/request_handling_test.rb
@@ -174,4 +174,25 @@ class RequestHandlingTest < Assert::Context
     end
   end
 
+  class HangingRequestTest < ErroringRequestTest
+    desc "when a client connects but doesn't send anything"
+    setup do
+      ENV['SANFORD_TIMEOUT'] = '0.1'
+    end
+    teardown do
+      ENV.delete('SANFORD_TIMEOUT')
+    end
+
+    should "timeout" do
+      self.start_server(@server) do
+        client = SimpleClient.new(@service_host, :with_delay => 0.2)
+        response = client.call_with_request('v1', 'echo', { :message => 'test' })
+
+        assert_equal 408,   response.status.code
+        assert_equal nil,   response.status.message
+        assert_equal nil,   response.data
+      end
+    end
+  end
+
 end

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -14,7 +14,7 @@ class Sanford::Connection
     end
     subject{ @connection }
 
-    should have_instance_methods :service_host, :exception_handler, :logger, :process
+    should have_instance_methods :service_host, :exception_handler, :logger, :process, :timeout
   end
 
   # The system test `test/system/request_handling_test.rb`, covers all the


### PR DESCRIPTION
This fixes a bug where Sanford would hang indefinitely waiting on a request to
be written. Instead it will now wait for a short period and then return a
timeout response.

Closes #19
