### PR TITLE
Changes to handle invalid sanford-protocol requests throwing exceptions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in sanford.gemspec
 gemspec
 
-gem 'sanford-protocol', :git => "git://github.com/redding/sanford-protocol.git"
+gem 'sanford-protocol', :git => "git://github.com/redding/sanford-protocol.git", :branch => "jcr-stringify-params"
 
 gem 'bson_ext'
 gem 'rake',     '~>0.9.2'

--- a/lib/sanford/connection.rb
+++ b/lib/sanford/connection.rb
@@ -36,7 +36,6 @@ module Sanford
       benchmark = Benchmark.measure do
         begin
           request = Sanford::Protocol::Request.parse(self.read(self.timeout))
-          self.validate!(request)
           self.log_request(request)
           status, data = self.route(request)
           response = Sanford::Protocol::Response.new(status, data)
@@ -61,11 +60,6 @@ module Sanford
       self.logger.info("  Version: #{request.version.inspect}")
       self.logger.info("  Service: #{request.name.inspect}")
       self.logger.info("  Parameters: #{request.params.inspect}")
-    end
-
-    def validate!(request)
-      valid, reason = request.valid?
-      raise(Sanford::Protocol::BadMessageError, reason) if !valid
     end
 
     def round_time(time_in_seconds)

--- a/lib/sanford/exception_handler.rb
+++ b/lib/sanford/exception_handler.rb
@@ -27,7 +27,7 @@ module Sanford
 
     def determine_code_and_message
       case(self.exception)
-      when Sanford::Protocol::BadMessageError
+      when Sanford::Protocol::BadMessageError, Sanford::Protocol::BadRequestError
         [ :bad_request, self.exception.message ]
       when Sanford::NotFoundError
         [ :not_found ]

--- a/test/system/request_handling_test.rb
+++ b/test/system/request_handling_test.rb
@@ -91,7 +91,9 @@ class RequestHandlingTest < Assert::Context
 
     should "return a bad request response" do
       self.start_server(@server) do
-        response = SimpleClient.call_with_request(@service_host, 'v1', nil, {})
+        request_hash = Sanford::Protocol::Request.new('v1', 'what', {}).to_hash
+        request_hash.delete('name')
+        response = SimpleClient.call_with_msg_body(@service_host, request_hash)
 
         assert_equal 400,       response.status.code
         assert_match "request", response.status.message
@@ -106,7 +108,9 @@ class RequestHandlingTest < Assert::Context
 
     should "return a bad request response" do
       self.start_server(@server) do
-        response = SimpleClient.call_with_request(@service_host, nil, 'what', {})
+        request_hash = Sanford::Protocol::Request.new('v1', 'what', {}).to_hash
+        request_hash.delete('version')
+        response = SimpleClient.call_with_msg_body(@service_host, request_hash)
 
         assert_equal 400,       response.status.code
         assert_match "request", response.status.message

--- a/test/unit/connection_test.rb
+++ b/test/unit/connection_test.rb
@@ -9,7 +9,7 @@ class Sanford::Connection
 
     desc "Sanford::Connection"
     setup do
-      @fake_socket = self.fake_socket_with_request('v1', 'echo', 'test')
+      @fake_socket = self.fake_socket_with_request('v1', 'echo', { :message => 'test' })
       @connection = Sanford::Connection.new(DummyHost.new, @fake_socket)
     end
     subject{ @connection }

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -112,7 +112,7 @@ module Sanford::Host
         service 'test', 'DummyHost::Echo'
       end
       @host = @host_class.new({ :port => 12000 })
-      @request = Sanford::Protocol::Request.new('v4', 'what', 'test')
+      @request = Sanford::Protocol::Request.new('v4', 'what', {})
     end
 
     should "raise a Sanford::NotFound exception" do
@@ -129,7 +129,7 @@ module Sanford::Host
         service 'test', 'DoesntExist::AtAll'
       end
       @host = @host_class.new({ :port => 12000 })
-      @request = Sanford::Protocol::Request.new('v1', 'test', 'test')
+      @request = Sanford::Protocol::Request.new('v1', 'test', {})
     end
 
     should "raise a Sanford::NoHandlerClass exception" do


### PR DESCRIPTION
When an invalid `Sanford::Protocol::Request` is created, it now throws
exceptions. These changes make `Sanford` work with that behavior. Previously,
Sanford would call the `valid?` method and throw it's own exceptions.

I removed the previous validating logic from the `Connection` class and then added the exception that is now being thrown to the `ExceptionHandler`. This doesn't change any of Sanford's behavior.
