### PR TITLE
Added summary logging option for hosts

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,9 +2,9 @@ Running benchmark report...
 
 Hitting "simple" service with {}, 10000 times
 ....................................................................................................
-Total Time:   15768.8473ms
-Average Time:     1.5768ms
-Min Time:         0.9949ms
-Max Time:       102.2670ms
+Total Time:   14987.9865ms
+Average Time:     1.4987ms
+Min Time:         0.9379ms
+Max Time:        94.4049ms
 
 Done running benchmark report

--- a/bench/services.rb
+++ b/bench/services.rb
@@ -1,8 +1,11 @@
 class BenchHost
   include Sanford::Host
 
-  self.port     = 12000
-  self.pid_dir  = File.expand_path("../../tmp", __FILE__)
+  self.port             = 12000
+  self.pid_dir          = File.expand_path("../../tmp", __FILE__)
+
+  self.logger           = Logger.new(STDOUT)
+  self.verbose_logging  = false
 
   version 'v1' do
     service 'simple', 'BenchHost::Simple'

--- a/lib/sanford.rb
+++ b/lib/sanford.rb
@@ -20,13 +20,4 @@ module Sanford
     require self.config.services_config
   end
 
-  class NullLogger
-    require 'logger'
-
-    Logger::Severity.constants.each do |name|
-      define_method(name.downcase){|*args| } # no-op
-    end
-
-  end
-
 end

--- a/lib/sanford/exception_handler.rb
+++ b/lib/sanford/exception_handler.rb
@@ -17,8 +17,8 @@ module Sanford
     end
 
     def response
-      self.logger.error("#{exception.class}: #{exception.message}")
-      self.logger.error(exception.backtrace.join("\n"))
+      self.logger.verbose.error("#{exception.class}: #{exception.message}")
+      self.logger.verbose.error(exception.backtrace.join("\n"))
       status = Sanford::Protocol::ResponseStatus.new(*self.determine_code_and_message)
       Sanford::Protocol::Response.new(status)
     end

--- a/lib/sanford/logger.rb
+++ b/lib/sanford/logger.rb
@@ -1,0 +1,23 @@
+module Sanford
+
+  class Logger
+    attr_reader :summary, :verbose
+
+    def initialize(logger, verbose = true)
+      loggers = [ logger, Sanford::NullLogger.new ]
+      loggers.reverse! if !verbose
+      @verbose, @summary = loggers
+    end
+
+  end
+
+  class NullLogger
+    require 'logger'
+
+    ::Logger::Severity.constants.each do |name|
+      define_method(name.downcase){|*args| } # no-op
+    end
+
+  end
+
+end

--- a/test/support/services.rb
+++ b/test/support/services.rb
@@ -7,8 +7,10 @@ class DummyHost
   port    12000
   pid_dir File.expand_path('../../../tmp/', __FILE__)
 
-  logger = Logger.new(File.expand_path("../../../log/test.log", __FILE__))
-  logger.level = Logger::DEBUG
+  logger(Logger.new(File.expand_path("../../../log/test.log", __FILE__)).tap do |logger|
+    logger.level = Logger::DEBUG
+  end)
+  verbose_logging false
 
   version 'v1' do
     service_handler_ns 'DummyHost'

--- a/test/unit/exception_handler_test.rb
+++ b/test/unit/exception_handler_test.rb
@@ -10,7 +10,7 @@ class Sanford::ExceptionHandler
         raise "test"
       rescue Exception => @exception
       end
-      @logger = Sanford::NullLogger.new
+      @logger = Sanford::Logger.new(Sanford::NullLogger.new)
       @exception_handler = Sanford::ExceptionHandler.new(@exception, @logger)
     end
     subject{ @exception_handler }


### PR DESCRIPTION
This adds a `verbose_logging` option that can be switched on and off. When on (the default) it will do the logging we currently have, this looks like:

```
Received request
  Version: "v1"
  Service: "echo"
  Parameters: {"message"=>"test"}
  Handler: "DummyHost::Echo"
Completed in 1.57ms [200, OK]
```

When verbose logging is turned off, you get:

```
version=v1 name=echo params={"message"=>"test"} status=200 duration=1.03
```

As far as implementation goes, I chose to create wrapper classes to avoid a bunch of conditionals. The summary logging adds almost no overhead as it is done after a response has already been written. I ran the benchmarking with summary logging on and it was comparable to having logging turned off.

Addresses #26
