### PR TITLE
Add before and after callbacks for init

### DIFF
--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -20,7 +20,9 @@ module Sanford
     end
 
     def init
+      self.run_callback 'before_init'
       self.init!
+      self.run_callback 'after_init'
     end
 
     def init!
@@ -43,6 +45,12 @@ module Sanford
     end
 
     protected
+
+    def before_init
+    end
+
+    def after_init
+    end
 
     def before_run
     end


### PR DESCRIPTION
This is to be robust and for allowing mixins to define before and
after init behavior in the same way they would for run.
