### PR TITLE
Added distribution listing to the standard benchmark report

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,9 +2,39 @@ Running benchmark report...
 
 Hitting "simple" service with {}, 10000 times
 ....................................................................................................
-Total Time:   10800.8833ms
-Average Time:     1.0800ms
-Min Time:         0.7009ms
-Max Time:        99.3640ms
+Total Time:   10195.4432ms
+Average Time:     1.0195ms
+Min Time:         0.7040ms
+Max Time:       117.8309ms
+
+Distribution (number of requests):
+  0ms: 8897
+    0.7ms: 6897
+    0.8ms: 1451
+    0.9ms: 549
+  1ms: 1049
+    1.0ms: 308
+    1.1ms: 236
+    1.2ms: 198
+    1.3ms: 134
+    1.4ms: 66
+    1.5ms: 44
+    1.6ms: 26
+    1.7ms: 18
+    1.8ms: 15
+    1.9ms: 4
+  117ms: 1
+  2ms: 24
+  3ms: 7
+  4ms: 2
+  82ms: 1
+  83ms: 1
+  84ms: 3
+  85ms: 2
+  86ms: 2
+  88ms: 3
+  89ms: 4
+  90ms: 2
+  91ms: 2
 
 Done running benchmark report

--- a/lib/sanford.rb
+++ b/lib/sanford.rb
@@ -5,6 +5,7 @@ require 'pathname'
 require 'set'
 
 require 'sanford/host'
+require 'sanford/server'
 require 'sanford/service_handler'
 require 'sanford/version'
 


### PR DESCRIPTION
This adds a listing of the distribution of request times. This
gives a more detailed idea of whats going on. With this
information you can tell if a benchmarking run was a better or
worse run (usually by how many outliers there are). It can
also be used to see if there has been a significant shift in
where most of the requests are landing based on recent changes.

@kellyredding - Added a distributions of benchmarks to the bench report. This gives you a good idea of how many outliers there are and that in general 80-90% of the requests are less than 1ms.
