### PR TITLE
rename `services_config` to `services_file`

### DIFF
--- a/lib/sanford.rb
+++ b/lib/sanford.rb
@@ -9,7 +9,7 @@ require 'sanford/server'
 require 'sanford/service_handler'
 require 'sanford/version'
 
-ENV['SANFORD_SERVICES_CONFIG'] ||= 'config/services'
+ENV['SANFORD_SERVICES_FILE'] ||= 'config/services'
 
 module Sanford
 
@@ -32,13 +32,12 @@ module Sanford
 
   def self.init
     @hosts ||= Hosts.new
-    require self.config.services_config
+    require self.config.services_file
   end
 
   module Config
     include NsOptions::Proxy
-
-    option :services_config,  Pathname, :default => ENV['SANFORD_SERVICES_CONFIG']
+    option :services_file,  Pathname, :default => ENV['SANFORD_SERVICES_FILE']
 
   end
 

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -7,7 +7,7 @@ ROOT = File.expand_path('../..', __FILE__)
 require 'sanford'
 
 Sanford.configure do |config|
-  config.services_config = File.join(ROOT, 'test/support/services')
+  config.services_file = File.join(ROOT, 'test/support/services')
 end
 Sanford.init
 

--- a/test/unit/config_test.rb
+++ b/test/unit/config_test.rb
@@ -6,7 +6,7 @@ module Sanford::Config
     desc "Sanford::Config"
     subject{ Sanford::Config }
 
-    should have_instance_methods :services_config
+    should have_instance_methods :services_file
   end
 
 end


### PR DESCRIPTION
This is to more accurately describe what that value is (a path to
a file) and to not use "config" in the name since there are already
so many "configs" floating around.

@jcredding pretty minor - meant to get this in earlier but forgot.  I know this may impact the test env setup of things using Sanford.  Anyway, here you go.
