### PR TITLE
Allow configuring a setup proc for hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,14 +144,16 @@ Define a `name` on a Host to set a string name for your host that can be used to
 
 ### Loading An Application
 
-Typically, a Sanford host is part of a larger application and parts of the application need to be setup or loaded when you start your Sanford server. The task `sanford:setup` is called before running any start, stop, or restart task; override it to hook in your application setup code:
+Typically, a Sanford host is part of a larger application and parts of the application need to be setup or loaded when you start your Sanford server. to support this, Sanford provides a `setup` hook for hosts. The proc that is defined will be called before the Sanford server is started, properly running the server in your application's environment:
 
 ```ruby
-# In your Rakefile
-namespace :sanford do
-  task :setup do
-    require 'config/environment'
+class MyHost
+  include Sanford::Host
+
+  setup do
+    require File.expand_path("../config/environment", __FILE__)
   end
+
 end
 ```
 

--- a/lib/sanford/exceptions.rb
+++ b/lib/sanford/exceptions.rb
@@ -5,7 +5,6 @@ module Sanford
   NotFoundError = Class.new(RuntimeError)
 
   class NoHostError < BaseError
-    attr_reader :message
 
     def initialize(host_name)
       message = if Sanford.hosts.empty?

--- a/lib/sanford/host.rb
+++ b/lib/sanford/host.rb
@@ -25,6 +25,7 @@ module Sanford
       option :logger,                     :default => proc{ Sanford::NullLogger.new }
       option :verbose_logging,            :default => true
       option :error_proc,       Proc,     :default => proc{ }
+      option :setup_proc,       Proc,     :default => proc{ }
 
       def initialize(host)
         self.name = host.class.to_s
@@ -73,6 +74,10 @@ module Sanford
 
     def error(&block)
       self.configuration.error_proc = block
+    end
+
+    def setup(&block)
+      self.configuration.setup_proc = block
     end
 
     def version(name, &block)

--- a/lib/sanford/host_data.rb
+++ b/lib/sanford/host_data.rb
@@ -20,12 +20,19 @@ module Sanford
       @pid_dir            = configuration[:pid_dir]
       @logger, @verbose   = configuration[:logger], configuration[:verbose_logging]
       @error_proc         = configuration[:error_proc]
+      @setup_proc         = configuration[:setup_proc]
 
-      @handlers = service_host.versioned_services.inject({}) do |hash, (version, services)|
-        hash.merge({ version => self.constantize_services(services) })
-      end
+      @versioned_services = service_host.versioned_services
+      @handlers = {}
 
       raise Sanford::InvalidHostError.new(service_host) if !self.port
+    end
+
+    def setup
+      @setup_proc.call
+      @handlers = @versioned_services.inject({}) do |hash, (version, services)|
+        hash.merge({ version => self.constantize_services(services) })
+      end
     end
 
     def handler_class_for(version, service)

--- a/lib/sanford/manager.rb
+++ b/lib/sanford/manager.rb
@@ -19,18 +19,18 @@ module Sanford
       self.new(service_host, options).call(action)
     end
 
-    attr_reader :host, :process_name
+    attr_reader :host_data, :process_name
 
     def initialize(service_host, options = {})
-      @host = Sanford::HostData.new(service_host, options)
-      @process_name = [ self.host.ip, self.host.port, self.host.name ].join('_')
+      @host_data = Sanford::HostData.new(service_host, options)
+      @process_name = [ self.host_data.ip, self.host_data.port, self.host_data.name ].join('_')
     end
 
     def call(action)
       daemons_options = self.default_options.merge({ :ARGV => [ action.to_s ] })
       FileUtils.mkdir_p(daemons_options[:dir])
       ::Daemons.run_proc(self.process_name, daemons_options) do
-        server = Sanford::Server.new(self.host)
+        server = Sanford::Server.new(self.host_data)
         server.start
         server.join_thread
       end
@@ -40,7 +40,7 @@ module Sanford
 
     def default_options
       { :dir_mode   => :normal,
-        :dir        => self.host.pid_dir
+        :dir        => self.host_data.pid_dir
       }
     end
 

--- a/lib/sanford/rake.rb
+++ b/lib/sanford/rake.rb
@@ -6,11 +6,7 @@ module Sanford::Rake
     def self.load
       namespace :sanford do
 
-        # Overwrite this to load your application's environment so that it can
-        # be used with Sanford
-        task :setup
-
-        task :load_manager => :setup do
+        task :load_manager do
           require 'sanford'
           require 'sanford/manager'
           Sanford.init

--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -13,6 +13,7 @@ module Sanford
 
     def initialize(host, options = {})
       @host_data = host.kind_of?(Sanford::HostData) ? host : Sanford::HostData.new(host)
+      @host_data.setup
       super(@host_data.ip, @host_data.port, options)
     end
 

--- a/test/support/services.rb
+++ b/test/support/services.rb
@@ -3,6 +3,12 @@ require 'logger'
 class TestHost
   include Sanford::Host
 
+  attr_accessor :setup_has_been_called
+
+  setup do
+    self.setup_has_been_called = true
+  end
+
   ip      'localhost'
   port    12000
   pid_dir File.expand_path('../../../tmp/', __FILE__)
@@ -106,6 +112,8 @@ end
 
 class UndefinedHandlersHost
   include Sanford::Host
+
+  port 12345
 
   version 'v1' do
     service 'undefined', 'ThisIsNotDefined'

--- a/test/unit/host_data_test.rb
+++ b/test/unit/host_data_test.rb
@@ -12,7 +12,7 @@ class Sanford::HostData
     subject{ @host_data }
 
     should have_instance_methods :name, :ip, :port, :pid_dir, :logger, :verbose,
-      :error_proc, :handler_class_for
+      :error_proc, :handler_class_for, :setup
 
     should "default it's configuration from the service host, but allow overrides" do
       host_data = Sanford::HostData.new(TestHost, :ip => '1.2.3.4', :port => 12345)
@@ -20,16 +20,6 @@ class Sanford::HostData
       assert_equal 'TestHost',  host_data.name
       assert_equal '1.2.3.4',   host_data.ip
       assert_equal 12345,       host_data.port
-    end
-
-    should "constantize a host's handlers" do
-      handlers = subject.instance_variable_get("@handlers")
-
-      assert_equal TestHost::Authorized,  handlers['v1']['authorized']
-      assert_equal TestHost::Bad,         handlers['v1']['bad']
-      assert_equal TestHost::Echo,        handlers['v1']['echo']
-      assert_equal TestHost::HaltIt,      handlers['v1']['halt_it']
-      assert_equal TestHost::Multiply,    handlers['v1']['multiply']
     end
 
     should "ignore nil values passed as overrides" do
@@ -44,7 +34,31 @@ class Sanford::HostData
       end
     end
 
-    should "look up handler classes with #handler_class_for" do
+  end
+
+  class SetupTest < BaseTest
+    desc "after calling setup"
+    setup do
+      TestHost.setup_has_been_called = false
+      @host_data.setup
+    end
+
+    should "have called the setup proc" do
+      assert_equal true, TestHost.setup_has_been_called
+
+      TestHost.setup_has_been_called = false
+    end
+
+    should "constantize a host's handlers" do
+      handlers = subject.instance_variable_get("@handlers")
+      assert_equal TestHost::Authorized,  handlers['v1']['authorized']
+      assert_equal TestHost::Bad,         handlers['v1']['bad']
+      assert_equal TestHost::Echo,        handlers['v1']['echo']
+      assert_equal TestHost::HaltIt,      handlers['v1']['halt_it']
+      assert_equal TestHost::Multiply,    handlers['v1']['multiply']
+    end
+
+        should "look up handler classes with #handler_class_for" do
       assert_equal TestHost::Echo, subject.handler_class_for('v1', 'echo')
     end
 
@@ -56,7 +70,7 @@ class Sanford::HostData
 
     should "raise a custom error when a service is configured with an undefined class" do
       assert_raises(Sanford::NoHandlerClassError) do
-        Sanford::HostData.new(UndefinedHandlersHost)
+        Sanford::HostData.new(UndefinedHandlersHost).setup
       end
     end
 

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -13,15 +13,13 @@ module Sanford::Host
     subject{ MyHost.instance }
 
     should have_instance_methods :configuration, :name, :ip, :port, :pid_dir, :logger,
-      :verbose_logging, :error, :version, :versioned_services
+      :verbose_logging, :error, :setup, :version, :versioned_services
 
     should "get and set it's configuration options with their matching methods" do
       subject.name 'my_awesome_host'
 
       assert_equal 'my_awesome_host',           subject.name
       assert_equal subject.configuration.port,  subject.port
-
-
     end
 
     should "add a version group with #version" do

--- a/test/unit/manager_test.rb
+++ b/test/unit/manager_test.rb
@@ -11,7 +11,7 @@ class Sanford::Manager
     end
     subject{ @manager }
 
-    should have_instance_methods :host, :process_name, :call
+    should have_instance_methods :host_data, :process_name, :call
     should have_class_methods :call
   end
 

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -24,7 +24,7 @@ class Sanford::Worker
 
     desc "Sanford::Worker"
     setup do
-      @host_data = Sanford::HostData.new(TestHost)
+      @host_data = Sanford::HostData.new(TestHost).tap{|hd| hd.setup }
       @connection = FakeConnection.with_request('version', 'service', {})
       @worker = Sanford::Worker.new(@host_data, @connection)
     end


### PR DESCRIPTION
This will be called before a server is initialized by and
run by the `Manager`. This should be used to load the environment
for the server to run in. This fixes bugs that came up with
loading the environment before using Daemons. Since Daemons is
trying to daemonize the process, it's better to let it do that
first and then load your environment after it's done it.

This also removes defining a `sanford:setup` task. The setup proc
should be used instead of this.
