### PR TITLE
Catch exceptions when writing the response

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require "bundler/gem_tasks"
 
-ENV['SANFORD_SERVICES_CONFIG'] = 'bench/services'
+ENV['SANFORD_SERVICES_FILE'] = 'bench/services'
 require 'sanford/rake'
 require 'bench/tasks'
 

--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,39 +2,39 @@ Running benchmark report...
 
 Hitting "simple" service with {}, 10000 times
 ....................................................................................................
-Total Time:   10195.4432ms
-Average Time:     1.0195ms
-Min Time:         0.7040ms
-Max Time:       117.8309ms
+Total Time:   10515.3759ms
+Average Time:     1.0515ms
+Min Time:         0.7140ms
+Max Time:       114.8610ms
 
 Distribution (number of requests):
-  0ms: 8897
-    0.7ms: 6897
-    0.8ms: 1451
-    0.9ms: 549
-  1ms: 1049
-    1.0ms: 308
-    1.1ms: 236
-    1.2ms: 198
-    1.3ms: 134
-    1.4ms: 66
-    1.5ms: 44
-    1.6ms: 26
-    1.7ms: 18
-    1.8ms: 15
+  0ms: 8614
+    0.7ms: 4945
+    0.8ms: 2641
+    0.9ms: 1028
+  1ms: 1339
+    1.0ms: 612
+    1.1ms: 370
+    1.2ms: 172
+    1.3ms: 90
+    1.4ms: 39
+    1.5ms: 19
+    1.6ms: 16
+    1.7ms: 10
+    1.8ms: 7
     1.9ms: 4
-  117ms: 1
-  2ms: 24
-  3ms: 7
-  4ms: 2
-  82ms: 1
-  83ms: 1
-  84ms: 3
-  85ms: 2
-  86ms: 2
-  88ms: 3
-  89ms: 4
-  90ms: 2
+  2ms: 15
+  3ms: 10
+  4ms: 1
+  66ms: 1
+  86ms: 3
+  87ms: 4
+  89ms: 2
+  90ms: 3
   91ms: 2
+  92ms: 2
+  93ms: 1
+  94ms: 2
+  114ms: 1
 
 Done running benchmark report

--- a/lib/sanford/error_handler.rb
+++ b/lib/sanford/error_handler.rb
@@ -7,8 +7,9 @@ module Sanford
 
     attr_reader :exception, :host_data, :request
 
-    def initialize(exception, host_data, request = nil)
+    def initialize(exception, host_data = nil, request = nil)
       @exception, @host_data, @request = exception, host_data, request
+      @error_proc = @host_data ? @host_data.error_proc : proc{ }
     end
 
     # The exception that we are generating a response for can change in the case
@@ -19,7 +20,7 @@ module Sanford
 
     def run
       begin
-        result = @host_data.error_proc.call(@exception, @host_data, @request)
+        result = @error_proc.call(@exception, @host_data, @request)
       rescue Exception => proc_exception
         @exception = proc_exception
       end

--- a/test/support/fake_connection.rb
+++ b/test/support/fake_connection.rb
@@ -2,16 +2,21 @@ class FakeConnection
 
   attr_reader :read_data, :response
 
-  def self.with_request(version, name, params = {})
+  def self.with_request(version, name, params = {}, raise_on_write = false)
     request = Sanford::Protocol::Request.new(version, name, params)
-    self.new(request.to_hash)
+    self.new(request.to_hash, raise_on_write)
   end
 
-  def initialize(read_data)
+  def initialize(read_data, raise_on_write = false)
+    @raise_on_write = raise_on_write
     @read_data = read_data
   end
 
   def write_data(data)
+    if @raise_on_write
+      @raise_on_write = false
+      raise 'test fail'
+    end
     @response = Sanford::Protocol::Response.parse(data)
   end
 

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -192,4 +192,22 @@ class Sanford::Worker
 
   end
 
+  class WithBadResponseHashTest < BaseTest
+    desc "running a request that builds an object that can't be encoded"
+    setup do
+      @connection = FakeConnection.with_request('v1', 'echo', { :message => 'cant encode' }, true)
+      @worker = Sanford::Worker.new(@host_data, @connection)
+    end
+
+    should "return the response that was halted" do
+      assert_raises(RuntimeError){ @worker.run }
+      response = @connection.response
+
+      assert_equal 500,                             response.status.code
+      assert_equal "An unexpected error occurred.", response.status.message
+      assert_equal nil,                             response.data
+    end
+
+  end
+
 end


### PR DESCRIPTION
This fixes exceptions that occur when a response's hash is trying
to be written to a socket. In particular, BSON converting a hash
can raise a number of exceptions. To ensure we get a response built
from the error and log messages that an error occurred, we now
handle exceptions raised when writing a response. This will trigger
Sanford's error handler and run only it's logic. In this case, we
don't want to trigger a user's logic because it's possible that
their error proc caused this fail. This is all trying to make sure
we respond with a valid response for any problems that occurred.
