### PR TITLE
Clean up load order issues

### DIFF
--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -12,8 +12,7 @@ module Sanford
     attr_reader :host_data
 
     def initialize(host, options = {})
-      @host_data = host.kind_of?(Sanford::HostData) ? host : Sanford::HostData.new(host)
-      @host_data.setup
+      @host_data = Sanford::HostData.new(host, options)
       super(@host_data.ip, @host_data.port, options)
     end
 

--- a/test/system/request_handling_test.rb
+++ b/test/system/request_handling_test.rb
@@ -21,7 +21,7 @@ class RequestHandlingTest < Assert::Context
       ENV.delete('SANFORD_PROTOCOL_DEBUG')
       ENV['SANFORD_DEBUG'] = '1'
 
-      @host_data = Sanford::HostData.new(TestHost).tap{|hd| hd.setup }
+      @host_data = Sanford::HostData.new(TestHost)
     end
     teardown do
       ENV['SANFORD_DEBUG'] = @env_sanford_debug
@@ -214,9 +214,7 @@ class RequestHandlingTest < Assert::Context
     end
 
     should "return a 200 response if the host expects keep-alive connections" do
-      host_data = Sanford::HostData.new(TestHost, { :receives_keep_alive => true }).tap do |hd|
-        hd.setup
-      end
+      host_data = Sanford::HostData.new(TestHost, { :receives_keep_alive => true })
       worker = Sanford::Worker.new(host_data, @connection)
 
       assert_raises(Sanford::Protocol::EndOfStreamError){ worker.run }
@@ -228,9 +226,7 @@ class RequestHandlingTest < Assert::Context
     end
 
     should "return a 500 response if the host doesn't expect keep-alive connections" do
-      host_data = Sanford::HostData.new(TestHost, { :receives_keep_alive => false }).tap do |hd|
-        hd.setup
-      end
+      host_data = Sanford::HostData.new(TestHost, { :receives_keep_alive => false })
       worker = Sanford::Worker.new(host_data, @connection)
 
       assert_raises(Sanford::Protocol::EndOfStreamError){ worker.run }

--- a/test/unit/host_data_test.rb
+++ b/test/unit/host_data_test.rb
@@ -7,46 +7,38 @@ class Sanford::HostData
   class BaseTest < Assert::Context
     desc "Sanford::HostData"
     setup do
+      TestHost.setup_has_been_called = false
       @host_data = Sanford::HostData.new(TestHost)
+    end
+    teardown do
+      TestHost.setup_has_been_called = false
     end
     subject{ @host_data }
 
-    should have_instance_methods :name, :ip, :port, :pid_dir, :logger, :verbose,
-      :error_proc, :handler_class_for, :setup
+    should have_instance_methods :ip, :port, :logger, :verbose,
+      :error_proc, :handler_class_for
 
     should "default it's configuration from the service host, but allow overrides" do
       host_data = Sanford::HostData.new(TestHost, :ip => '1.2.3.4', :port => 12345)
 
-      assert_equal 'TestHost',  host_data.name
       assert_equal '1.2.3.4',   host_data.ip
       assert_equal 12345,       host_data.port
+      assert_equal true,        host_data.verbose
     end
 
     should "ignore nil values passed as overrides" do
       host_data = Sanford::HostData.new(TestHost, :ip => nil)
-
       assert_not_nil host_data.ip
     end
 
-    should "raise a custom exception when passed invalid host" do
+    should "raise a custom exception when passed an invalid host" do
       assert_raises(Sanford::InvalidHostError) do
-        Sanford::Manager.new(InvalidHost)
+        Sanford::HostData.new(InvalidHost)
       end
-    end
-
-  end
-
-  class SetupTest < BaseTest
-    desc "after calling setup"
-    setup do
-      TestHost.setup_has_been_called = false
-      @host_data.setup
     end
 
     should "have called the setup proc" do
       assert_equal true, TestHost.setup_has_been_called
-
-      TestHost.setup_has_been_called = false
     end
 
     should "constantize a host's handlers" do
@@ -58,7 +50,7 @@ class Sanford::HostData
       assert_equal TestHost::Multiply,    handlers['v1']['multiply']
     end
 
-        should "look up handler classes with #handler_class_for" do
+    should "look up handler classes with #handler_class_for" do
       assert_equal TestHost::Echo, subject.handler_class_for('v1', 'echo')
     end
 

--- a/test/unit/manager_test.rb
+++ b/test/unit/manager_test.rb
@@ -11,8 +11,9 @@ class Sanford::Manager
     end
     subject{ @manager }
 
-    should have_instance_methods :host_data, :process_name, :call
+    should have_instance_methods :process_name, :call
     should have_class_methods :call
+
   end
 
   # Sanford::Manager#call methods are tested in the test/system/managing_test.rb

--- a/test/unit/worker_test.rb
+++ b/test/unit/worker_test.rb
@@ -9,7 +9,7 @@ class Sanford::Worker
 
     desc "Sanford::Worker"
     setup do
-      @host_data = Sanford::HostData.new(TestHost).tap{|hd| hd.setup }
+      @host_data = Sanford::HostData.new(TestHost)
       @connection = FakeConnection.with_request('version', 'service', {})
       @worker = Sanford::Worker.new(@host_data, @connection)
     end


### PR DESCRIPTION
While integrating Sanford, I realized there were some load order
issues that were causing bad values "locked" into `HostData`
instances. This stemmed from 2 issues:
- When the `setup` proc was being called
- The `Manager` class using the `HostData`

In many cases, the `Host` configuration relies on loading the
environment, which is done by the `setup` proc. Thus the `setup`
proc needs to be called before we store the configuration in a
`HostData` instance. Doing this though, causes problems with the
`Manager`. This is because the `setup` proc is now loading the
environment before we have forked (using Daemons), which is why
we added the `setup` proc in a previous commit. The issues is the
coupling of `HostData` to both the `Server` and `Manager`. This
removes the coupling and alters when the `setup` proc is called.

@kellyredding - More obscure issues. I noticed this cause my logger was not being set correctly.
