### PR TITLE
Handle "keep-alive" connections by ignoring them completely

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,3 @@ gemspec
 
 gem 'bson_ext'
 gem 'rake',     '~>0.9.2'
-
-gem 'sanford-protocol',
-  :git => 'git://github.com/redding/sanford-protocol.git', :branch => "v0.5.2"

--- a/lib/sanford/error_handler.rb
+++ b/lib/sanford/error_handler.rb
@@ -47,12 +47,6 @@ module Sanford
         build_response :not_found
       when Sanford::Protocol::TimeoutError
         build_response :timeout
-      when Sanford::Protocol::EndOfStreamError
-        if @keep_alive
-          build_response :ok
-        else
-          build_response :bad_request, :message => "Couldn't read request."
-        end
       when Exception
         build_response :error, :message => "An unexpected error occurred."
       end

--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -12,7 +12,7 @@ module Sanford
     attr_reader :host_data
 
     def initialize(host, options = {})
-      @host_data = Sanford::HostData.new(host, options)
+      @host_data    = Sanford::HostData.new(host, options)
       super(@host_data.ip, @host_data.port, options)
     end
 
@@ -23,12 +23,21 @@ module Sanford
     # `serve` can be called at the same time by multiple threads. Thus we create
     # a new instance of the handler for every request.
     def serve(socket)
-      Sanford::Worker.new(@host_data, Connection.new(socket)).run
+      connection = Connection.new(socket)
+      if !self.keep_alive_connection?(connection)
+        Sanford::Worker.new(@host_data, connection).run
+      end
     end
 
     def inspect
       reference = '0x0%x' % (self.object_id << 1)
       "#<#{self.class}:#{reference} @service_host=#{@host_data.inspect}>"
+    end
+
+    protected
+
+    def keep_alive_connection?(connection)
+      @host_data.keep_alive && connection.peek_data.empty?
     end
 
     class Connection
@@ -46,6 +55,10 @@ module Sanford
 
       def write_data(data)
         @connection.write data
+      end
+
+      def peek_data
+        @connection.peek(@timeout)
       end
 
     end

--- a/test/support/simple_client.rb
+++ b/test/support/simple_client.rb
@@ -35,6 +35,12 @@ class SimpleClient
     self.call_using_fake_socket(:with_encoded_msg_body, *args)
   end
 
+  def call_with_keep_alive
+    socket = TCPSocket.new(@host, @port)
+  ensure
+    socket.close rescue false
+  end
+
   def call(bytes)
     socket = TCPSocket.new(@host, @port)
     socket.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)

--- a/test/unit/error_handler_test.rb
+++ b/test/unit/error_handler_test.rb
@@ -121,24 +121,6 @@ class Sanford::ErrorHandler
       assert_nil response.status.message
     end
 
-    should "build a 200 response with an EndOfStreamError when the host data expects it" do
-      host_data = Sanford::HostData.new(TestHost, { :receives_keep_alive => true })
-      exception = Sanford::Protocol::EndOfStreamError.new
-      response = Sanford::ErrorHandler.new(exception, host_data).run
-
-      assert_equal 200, response.code
-      assert_nil response.status.message
-    end
-
-    should "build a 400 response with an EndOfStreamError when the host data doesn't expect it" do
-      host_data = Sanford::HostData.new(TestHost, { :receives_keep_alive => false })
-      exception = Sanford::Protocol::EndOfStreamError.new
-      response = Sanford::ErrorHandler.new(exception, host_data).run
-
-      assert_equal 400,                       response.code
-      assert_equal "Couldn't read request.",  response.status.message
-    end
-
     should "build a 500 response with all other exceptions" do
       response = Sanford::ErrorHandler.new(RuntimeError.new('test'), @host_data).run
 


### PR DESCRIPTION
This modifies the "keep-alive" handling to ignore them completely.
This is possible because the server has the ability to "peek" at
what's been written to a socket. With this we can detect if the
socket has been closed (reading returns an empty string) and
choose to ignore the request before any processing is done. This
is nice because it reduces the overhead of a monitoring tool
checking in to make sure the server is up and running.

Closes #47
