### PR TITLE
Manually connect the server before running start

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,5 @@ gemspec
 
 gem 'bson_ext'
 gem 'rake',     '~>0.9.2'
+
+gem 'dat-tcp', :path => "~/Projects/redding/gems/dat-tcp"

--- a/lib/sanford/manager.rb
+++ b/lib/sanford/manager.rb
@@ -32,6 +32,10 @@ module Sanford
       FileUtils.mkdir_p(daemons_options[:dir])
       ::Daemons.run_proc(self.process_name, daemons_options) do
         server = Sanford::Server.new(@service_host, @host_options)
+        server.connect
+
+        Signal.trap("TERM"){ server.stop }
+
         server.start
         server.join_thread
       end

--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -9,15 +9,15 @@ module Sanford
   class Server
     include DatTCP::Server
 
-    attr_reader :host_data
-
     def initialize(host, options = {})
-      @host_data    = Sanford::HostData.new(host, options)
-      super(@host_data.ip, @host_data.port, options)
+      @service_host, @host_options = host, options
+      ip    = options[:ip]   || host.ip
+      port  = options[:port] || host.port
+      super(ip, port, options)
     end
 
-    def name
-      @host_data.name
+    def on_start
+      @host_data = Sanford::HostData.new(@service_host, @host_options)
     end
 
     # `serve` can be called at the same time by multiple threads. Thus we create

--- a/test/system/request_handling_test.rb
+++ b/test/system/request_handling_test.rb
@@ -323,6 +323,7 @@ class RequestHandlingTest < Assert::Context
         :ready_timeout        => 0,
         :receives_keep_alive  => true
       })
+      @server.on_start
       @socket = Sanford::Protocol::Test::FakeSocket.new
       @fake_connection = FakeProtocolConnection.new(@socket)
       Sanford::Protocol::Connection.stubs(:new).with(@socket).returns(@fake_connection)


### PR DESCRIPTION
This changes Sanford to manually connect it's server (so it starts
queueing up connections) before starting it. This also moves the
creation of the `HostData` to an `on_start` callback. The net
effect is that the server will bind and begin listening before
the `HostData` trys to load the app's environment. This enables
faster start times, which means less dropped connections.
