### PR TITLE
Performance tweaks on sockets Sanford interacts with

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,43 +2,37 @@ Running benchmark report...
 
 Hitting "simple" service with {}, 10000 times
 ....................................................................................................
-Total Time:   9089.0492ms
-Average Time:    0.9089ms
-Min Time:        0.5171ms
-Max Time:       90.8720ms
+Total Time:   8960.5727ms
+Average Time:    0.8960ms
+Min Time:        0.5099ms
+Max Time:       87.5380ms
 
 Distribution (number of requests):
-  0ms: 9691
-    0.5ms: 4388
-    0.6ms: 3538
-    0.7ms: 1016
-    0.8ms: 550
-    0.9ms: 199
-  1ms: 234
-    1.0ms: 94
-    1.1ms: 42
-    1.2ms: 39
-    1.3ms: 25
-    1.4ms: 15
-    1.5ms: 5
-    1.6ms: 6
-    1.7ms: 4
-    1.8ms: 3
+  0ms: 9775
+    0.5ms: 5723
+    0.6ms: 2810
+    0.7ms: 733
+    0.8ms: 364
+    0.9ms: 145
+  1ms: 153
+    1.0ms: 57
+    1.1ms: 18
+    1.2ms: 42
+    1.3ms: 13
+    1.4ms: 8
+    1.5ms: 7
+    1.6ms: 2
+    1.7ms: 3
+    1.8ms: 2
     1.9ms: 1
-  2ms: 18
-  3ms: 6
-  7ms: 1
-  45ms: 3
-  46ms: 20
-  47ms: 15
-  48ms: 2
-  49ms: 1
-  51ms: 1
-  56ms: 1
-  59ms: 1
+  2ms: 16
+  3ms: 1
+  22ms: 1
+  44ms: 10
+  45ms: 25
+  46ms: 9
+  47ms: 4
+  85ms: 3
   87ms: 3
-  88ms: 1
-  89ms: 1
-  90ms: 1
 
 Done running benchmark report

--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -21,17 +21,29 @@ module Sanford
       super options
     end
 
+    # TCP_NODELAY is set to disable buffering. In the case of Sanford
+    # communication, we have all the information we need to send up front and
+    # are closing the connection, so it doesn't need to buffer.
+    # See http://linux.die.net/man/7/tcp
+    def configure_tcp_server(tcp_server)
+      tcp_server.setsockopt(::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true)
+    end
+
     def on_run
       @sanford_host_data = Sanford::HostData.new(@sanford_host, @sanford_host_options)
     end
 
     # `serve` can be called at the same time by multiple threads. Thus we create
     # a new instance of the handler for every request.
+    # When using TCP_CORK, you "cork" the socket, handle it and then "uncork"
+    # it, see the `TCPCork` module for more info.
     def serve(socket)
+      TCPCork.apply(socket)
       connection = Connection.new(socket)
       if !self.keep_alive_connection?(connection)
         Sanford::Worker.new(@sanford_host_data, connection).run
       end
+      TCPCork.remove(socket)
     end
 
     protected
@@ -59,6 +71,34 @@ module Sanford
 
       def peek_data
         @connection.peek(@timeout)
+      end
+
+    end
+
+    module TCPCork
+
+      # On Linux, use TCP_CORK to better control how the TCP stack
+      # packetizes our stream. This improves both latency and throughput.
+      # TCP_CORK disables Nagle's algorithm, which is ideal for sporadic
+      # traffic (like Telnet) but is less optimal for HTTP. Sanford is similar
+      # to HTTP, it doesn't receive sporadic packets, it has all it's data
+      # come in at once.
+      # For more information: http://baus.net/on-tcp_cork
+      if RUBY_PLATFORM =~ /linux/
+        # 3 == TCP_CORK
+        def self.apply(socket)
+          socket.setsockopt(Socket::IPPROTO_TCP, 3, true)
+        end
+
+        def self.remove(socket)
+          socket.setsockopt(Socket::IPPROTO_TCP, 3, false)
+        end
+      else
+        def self.apply(socket)
+        end
+
+        def self.remove(socket)
+        end
       end
 
     end


### PR DESCRIPTION
This adds the TCP_NODELAY option to Sanford's server socket and
corks and uncorks client sockets with TCP_CORK (only on Linux).
Both of these do similar things, and are related to disabling
Nagle's algorithm for improved performance. Nagle's algorithm is
ideal for applications, like Telnet, that send sporadic packets
(as a user types). For HTTP (and Sanford) it isn't ideal, because
all the data is ready to be sent at once, not sporadically.
