### PR TITLE
Switch the `setup` proc to `init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,13 +144,13 @@ Define a `name` on a Host to set a string name for your host that can be used to
 
 ### Loading An Application
 
-Typically, a Sanford host is part of a larger application and parts of the application need to be setup or loaded when you start your Sanford server. to support this, Sanford provides a `setup` hook for hosts. The proc that is defined will be called before the Sanford server is started, properly running the server in your application's environment:
+Typically, a Sanford host is part of a larger application and parts of the application need to be initialized or loaded when you start your Sanford server. To support this, Sanford provides an `init` hook for hosts. The proc that is defined will be called before the Sanford server is started, properly running the server in your application's environment:
 
 ```ruby
 class MyHost
   include Sanford::Host
 
-  setup do
+  init do
     require File.expand_path("../config/environment", __FILE__)
   end
 

--- a/lib/sanford/host.rb
+++ b/lib/sanford/host.rb
@@ -26,7 +26,7 @@ module Sanford
       option :verbose_logging,                :default => true
       option :receives_keep_alive,            :default => false
       option :error_proc,           Proc,     :default => proc{ }
-      option :setup_proc,           Proc,     :default => proc{ }
+      option :init_proc,            Proc,     :default => proc{ }
 
       def initialize(host)
         self.name = host.class.to_s
@@ -81,8 +81,8 @@ module Sanford
       self.configuration.error_proc = block
     end
 
-    def setup(&block)
-      self.configuration.setup_proc = block
+    def init(&block)
+      self.configuration.init_proc = block
     end
 
     def version(name, &block)

--- a/lib/sanford/host_data.rb
+++ b/lib/sanford/host_data.rb
@@ -14,7 +14,7 @@ module Sanford
     attr_reader :name, :logger, :verbose, :keep_alive, :error_proc
 
     def initialize(service_host, options = nil)
-      service_host.configuration.setup_proc.call
+      service_host.configuration.init_proc.call
 
       overrides = self.remove_nil_values(options || {})
       configuration = service_host.configuration.to_hash.merge(overrides)

--- a/test/support/services.rb
+++ b/test/support/services.rb
@@ -3,10 +3,10 @@ require 'logger'
 class TestHost
   include Sanford::Host
 
-  attr_accessor :setup_has_been_called
+  attr_accessor :init_has_been_called
 
-  setup do
-    self.setup_has_been_called = true
+  init do
+    self.init_has_been_called = true
   end
 
   ip       'localhost'

--- a/test/unit/host_data_test.rb
+++ b/test/unit/host_data_test.rb
@@ -5,11 +5,11 @@ class Sanford::HostData
   class BaseTest < Assert::Context
     desc "Sanford::HostData"
     setup do
-      TestHost.setup_has_been_called = false
+      TestHost.init_has_been_called = false
       @host_data = Sanford::HostData.new(TestHost)
     end
     teardown do
-      TestHost.setup_has_been_called = false
+      TestHost.init_has_been_called = false
     end
     subject{ @host_data }
 
@@ -29,7 +29,7 @@ class Sanford::HostData
     end
 
     should "have called the setup proc" do
-      assert_equal true, TestHost.setup_has_been_called
+      assert_equal true, TestHost.init_has_been_called
     end
 
     should "constantize a host's handlers" do

--- a/test/unit/host_test.rb
+++ b/test/unit/host_test.rb
@@ -13,7 +13,7 @@ module Sanford::Host
     subject{ MyHost.instance }
 
     should have_instance_methods :configuration, :name, :ip, :port, :pid_file,
-      :logger, :verbose_logging, :error, :setup, :version, :versioned_services
+      :logger, :verbose_logging, :error, :init, :version, :versioned_services
 
     should "get and set it's configuration options with their matching methods" do
       subject.name 'my_awesome_host'


### PR DESCRIPTION
This renames the `setup` proc that you can configure on a `Host`
to `init`. This is better naming for this configuration and
more accurately describes the intent of initializing the
environment with this proc.
