### PR TITLE
Allow configuring multiple error procs

### DIFF
--- a/lib/sanford/host.rb
+++ b/lib/sanford/host.rb
@@ -26,7 +26,7 @@ module Sanford
       option :verbose_logging,                :default => true
       option :receives_keep_alive,            :default => false
       option :runner,                         :default => proc{ Sanford.config.runner }
-      option :error_proc,           Proc,     :default => proc{ }
+      option :error_procs,          Array,    :default => []
       option :init_proc,            Proc,     :default => proc{ }
 
       def initialize(host)
@@ -83,7 +83,7 @@ module Sanford
     end
 
     def error(&block)
-      self.configuration.error_proc = block
+      self.configuration.error_procs << block
     end
 
     def init(&block)

--- a/lib/sanford/host_data.rb
+++ b/lib/sanford/host_data.rb
@@ -11,7 +11,7 @@ module Sanford
 
     # NOTE: The `name` attribute shouldn't be removed, it is used to identify
     # a `HostData`, particularly in error handlers
-    attr_reader :name, :logger, :verbose, :keep_alive, :runner, :error_proc
+    attr_reader :name, :logger, :verbose, :keep_alive, :runner, :error_procs
 
     def initialize(service_host, options = nil)
       service_host.configuration.init_proc.call
@@ -19,12 +19,12 @@ module Sanford
       overrides = self.remove_nil_values(options || {})
       configuration = service_host.configuration.to_hash.merge(overrides)
 
-      @name       = configuration[:name]
-      @logger     = configuration[:logger]
-      @verbose    = configuration[:verbose_logging]
-      @keep_alive = configuration[:receives_keep_alive]
-      @runner     = configuration[:runner]
-      @error_proc = configuration[:error_proc]
+      @name        = configuration[:name]
+      @logger      = configuration[:logger]
+      @verbose     = configuration[:verbose_logging]
+      @keep_alive  = configuration[:receives_keep_alive]
+      @runner      = configuration[:runner]
+      @error_procs = configuration[:error_procs]
 
       @handlers = service_host.versioned_services.inject({}) do |hash, (version, services)|
         hash.merge({ version => self.constantize_services(services) })

--- a/test/unit/host_configuration_test.rb
+++ b/test/unit/host_configuration_test.rb
@@ -10,7 +10,7 @@ class Sanford::Host::Configuration
     subject{ @configuration }
 
     should have_instance_methods :name, :ip, :port, :pid_file, :logger,
-      :verbose_logging, :logger, :error_proc
+      :verbose_logging, :logger, :error_procs
 
     should "default name to the class name of the host" do
       assert_equal 'EmptyHost', subject.name

--- a/test/unit/host_data_test.rb
+++ b/test/unit/host_data_test.rb
@@ -14,7 +14,7 @@ class Sanford::HostData
     subject{ @host_data }
 
     should have_instance_methods :name, :logger, :verbose, :keep_alive, :runner,
-      :error_proc, :run, :handler_class_for
+      :error_procs, :run, :handler_class_for
 
     should "default it's configuration from the service host, but allow overrides" do
       host_data = Sanford::HostData.new(TestHost, :verbose_logging => false)


### PR DESCRIPTION
This updates Sanford hosts to allow configuring multiple error
procs. Sanford error handling will call all of them, but will
only use the last configured proc's response (if it generated
one). This should dictate that the most "specific" error proc's
response will be used. This is to allow flexibility of
configuring a host using mixins or other methods.
