### PR TITLE
Close the write stream of the socket after writing a response

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,6 @@ gemspec
 
 gem 'bson_ext'
 gem 'rake',     '~>0.9.2'
+
+gem 'sanford-protocol',
+  :git => "git://github.com/redding/sanford-protocol.git", :branch => "jcr-allow-closing-da-write"

--- a/bench/client.rb
+++ b/bench/client.rb
@@ -16,6 +16,7 @@ module Bench
       connection = Sanford::Protocol::Connection.new(socket)
       request = Sanford::Protocol::Request.new(version, name, params)
       connection.write(request.to_hash)
+      connection.close_write
       if IO.select([ socket ], nil, nil, 10)
         Sanford::Protocol::Response.parse(connection.read)
       else

--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,37 +2,36 @@ Running benchmark report...
 
 Hitting "simple" service with {}, 10000 times
 ....................................................................................................
-Total Time:   8960.5727ms
-Average Time:    0.8960ms
-Min Time:        0.5099ms
-Max Time:       87.5380ms
+Total Time:   8171.4835ms
+Average Time:    0.8171ms
+Min Time:        0.5269ms
+Max Time:       91.8741ms
 
 Distribution (number of requests):
-  0ms: 9775
-    0.5ms: 5723
-    0.6ms: 2810
-    0.7ms: 733
-    0.8ms: 364
-    0.9ms: 145
-  1ms: 153
-    1.0ms: 57
-    1.1ms: 18
-    1.2ms: 42
-    1.3ms: 13
-    1.4ms: 8
-    1.5ms: 7
-    1.6ms: 2
-    1.7ms: 3
-    1.8ms: 2
-    1.9ms: 1
-  2ms: 16
-  3ms: 1
-  22ms: 1
-  44ms: 10
-  45ms: 25
-  46ms: 9
-  47ms: 4
-  85ms: 3
-  87ms: 3
+  0ms: 9861
+    0.5ms: 5432
+    0.6ms: 3268
+    0.7ms: 727
+    0.8ms: 291
+    0.9ms: 143
+  1ms: 102
+    1.0ms: 47
+    1.1ms: 30
+    1.2ms: 15
+    1.3ms: 7
+    1.4ms: 1
+    1.6ms: 1
+    1.7ms: 1
+  2ms: 7
+  3ms: 2
+  4ms: 5
+  47ms: 1
+  56ms: 1
+  85ms: 5
+  86ms: 4
+  88ms: 1
+  89ms: 3
+  90ms: 3
+  91ms: 5
 
 Done running benchmark report

--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -73,6 +73,10 @@ module Sanford
         @connection.peek(@timeout)
       end
 
+      def close_write
+        @connection.close_write
+      end
+
     end
 
     module TCPCork

--- a/lib/sanford/worker.rb
+++ b/lib/sanford/worker.rb
@@ -61,6 +61,7 @@ module Sanford
         service = self.handle_exception(service, exception)
         @connection.write_data service.response.to_hash
       end
+      @connection.close_write
       service
     end
 

--- a/test/support/fake_connection.rb
+++ b/test/support/fake_connection.rb
@@ -1,6 +1,6 @@
 class FakeConnection
 
-  attr_reader :read_data, :response
+  attr_reader :read_data, :response, :write_stream_closed
 
   def self.with_request(version, name, params = {}, raise_on_write = false)
     request = Sanford::Protocol::Request.new(version, name, params)
@@ -27,6 +27,10 @@ class FakeConnection
       raise 'test fail'
     end
     @response = Sanford::Protocol::Response.parse(data)
+  end
+
+  def close_write
+    @write_stream_closed = true
   end
 
 end

--- a/test/system/request_handling_test.rb
+++ b/test/system/request_handling_test.rb
@@ -40,6 +40,12 @@ class RequestHandlingTest < Assert::Context
       assert_equal 'test',  response.data
     end
 
+    should "have cloased the connection's write stream" do
+      assert_nothing_raised{ @worker.run }
+
+      assert_equal true, @connection.write_stream_closed
+    end
+
   end
 
   class MissingServiceVersionTest < FakeConnectionTest


### PR DESCRIPTION
This closes the write stream of the socket after writing a
response. The benefit is notifying the client that we are done
writing the response and that it can begin reading it. The
client/socket usually figures this out, but closing it manually
is more reliable.
