### PR TITLE
Add `Sanford` tag to log messages

### DIFF
--- a/test/support/services.rb
+++ b/test/support/services.rb
@@ -16,7 +16,7 @@ class TestHost
   logger(Logger.new(File.expand_path("../../../log/test.log", __FILE__)).tap do |logger|
     logger.level = Logger::DEBUG
   end)
-  verbose_logging true
+  verbose_logging false
 
   error do |exception, host_data, request|
     if exception.kind_of?(::MyCustomError)


### PR DESCRIPTION
This modifies Sanford's logging to prepend a `[Sanford]` tag to
all it's log messages. This is for identification purposes of
where the logging is coming from. In addition to this, I
implemented some summary line cleanups from `AndSon`. This moves
the `time` and `status` to the front of the log messages to
help visually read those values.

Closes #67
