### PR TITLE
better server start, stop, halt, restart logging

### DIFF
--- a/test/unit/manager_pid_file_tests.rb
+++ b/test/unit/manager_pid_file_tests.rb
@@ -40,12 +40,13 @@ class Sanford::Manager::PIDFile
       assert_not File.exists?(@pid_file_path)
     end
 
-    should "complain nicely if the pid file dir doesn't exist or isn't writeable" do
+    should "complain nicely if it can't write the pid file" do
       pid_file_path = 'does/not/exist.pid'
+      pid_file = Sanford::Manager::PIDFile.new(pid_file_path)
 
       err = nil
       begin
-        Sanford::Manager::PIDFile.new(pid_file_path)
+        pid_file.write
       rescue Exception => err
       end
 


### PR DESCRIPTION
This is related to requests in #63.

This updated the logging of how a server is started stopped and
restarted.  Here are the key changes:
- catch any startup runtime errors and log them
  - covers logging the write pid file error in #63
  - covers any load errors (like trying to use a handler that hasn't
    been defined)
- updates log messages to be explicit both when an action starts
  and we it finishes

@jcredding no major behavior changes - just better error capturing and logging.  The goal is to be as clear as possible about the what happened and the state of the server.  Ready for review.
