### PR TITLE
Don't re-daemonize the process when restarting

### DIFF
--- a/lib/sanford/cli.rb
+++ b/lib/sanford/cli.rb
@@ -84,7 +84,7 @@ module Sanford
       end
 
       def run
-        self.run!
+        self.run! false
       end
 
       def start
@@ -94,7 +94,7 @@ module Sanford
       protected
 
       def run!(daemonize = false)
-        daemonize!(true) if daemonize
+        daemonize!(true) if daemonize && !ENV['SANFORD_SKIP_DAEMONIZE']
         Sanford::Server.new(@host, @server_options).tap do |server|
           log "Starting #{@host.name} server..."
 
@@ -125,9 +125,10 @@ module Sanford
         server.pause
         log "server paused"
 
-        ENV['SANFORD_HOST']        = @host.name
-        ENV['SANFORD_SERVER_FD']   = server.file_descriptor.to_s
-        ENV['SANFORD_CLIENT_FDS']  = server.client_file_descriptors.join(',')
+        ENV['SANFORD_HOST']           = @host.name
+        ENV['SANFORD_SERVER_FD']      = server.file_descriptor.to_s
+        ENV['SANFORD_CLIENT_FDS']     = server.client_file_descriptors.join(',')
+        ENV['SANFORD_SKIP_DAEMONIZE'] = 'yes'
 
         log "calling exec ..."
         Dir.chdir @restart_cmd.dir


### PR DESCRIPTION
Currently, Sanford re-daemonizes it's process when it is
restarted. This isn't ideal because the PID changes, which isn't
the intent with a "hot" restart using exec. This seems to also
cause issues with some monitoring tools losing the process they
should be monitoring.

@kellyredding - This works, but I have another idea I'm gonna try. I don't like analyzing the command they typed. I think I'm going to store a `@daemonize` flag to be explicit that the previous process was daemonized by Sanford (regardless of the command they used) and that we need to undo that when restarting it. I'll comment when I've got it ready to review. 
