### PR TITLE
test runner raises custom exception if given an invalid handler class

### DIFF
--- a/lib/sanford/test_runner.rb
+++ b/lib/sanford/test_runner.rb
@@ -1,12 +1,23 @@
 require 'sanford-protocol'
 require 'sanford/runner'
+require 'sanford/service_handler'
 
 module Sanford
+
+  InvalidServiceHandlerError = Class.new(RuntimeError)
 
   class TestRunner
     include Sanford::Runner
 
     attr_reader :handler, :response
+
+    def initialize(handler_class, *args)
+      if !handler_class.include?(Sanford::ServiceHandler)
+        raise InvalidServiceHandlerError, "#{handler_class.inspect} is not a"\
+                                          " Sanford::ServiceHandler"
+      end
+      super
+    end
 
     def init!
       if !@request.kind_of?(Sanford::Protocol::Request)

--- a/test/support/service_handlers.rb
+++ b/test/support/service_handlers.rb
@@ -62,6 +62,8 @@ class HaltServiceHandler
 
 end
 
+class InvalidServiceHandler; end
+
 class HaltingBehaviorServiceHandler < FlagServiceHandler
 
   def before_init

--- a/test/unit/service_handler_tests.rb
+++ b/test/unit/service_handler_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'sanford/service_handler'
 
 require 'sanford/test_helpers'
+require 'test/support/service_handlers'
 
 module Sanford::ServiceHandler
 
@@ -69,7 +70,7 @@ module Sanford::ServiceHandler
   end
 
   class HaltTests < UnitTests
-    desc "halt"
+    desc "when halted"
 
     should "return a response with the status code and the passed data" do
       runner = test_runner(HaltServiceHandler, {
@@ -98,7 +99,7 @@ module Sanford::ServiceHandler
   end
 
   class HaltingTests < UnitTests
-    desc "halting at different points"
+    desc "when halted at different points"
 
     should "not call `init!, `after_init`, `run!` or run's callbacks when `before_init` halts" do
       runner = test_runner(HaltingBehaviorServiceHandler, {
@@ -194,6 +195,17 @@ module Sanford::ServiceHandler
       assert_equal true, response.data[:after_run_called]
 
       assert_equal 'after_run halting', runner.response.status.message
+    end
+
+  end
+
+  class InvalidHandlerTests < UnitTests
+    desc "that is invalid"
+
+    should "raise a custom error when initialized in a test" do
+      assert_raises Sanford::InvalidServiceHandlerError do
+        test_handler(InvalidServiceHandler)
+      end
     end
 
   end


### PR DESCRIPTION
This updates the test runner to validate its given handler class
includes `Sanford::ServiceHandler`.  This main reason for this is
that if you forget to include, the default error is some cryptic
argument error.  This makes it so that instead of a cryptic error,
you get a very specific error that tells you what the problem is.

I've only added this logic to the test runner to not add the overhead
of this check to every live request.

Closes #79.

@jcredding ready for review.
