### PR TITLE
recursively sanitize response objects

### DIFF
--- a/test/support/service_handlers.rb
+++ b/test/support/service_handlers.rb
@@ -12,6 +12,47 @@ class BasicServiceHandler
 
 end
 
+class SanitzeDataServiceHandler
+  include Sanford::ServiceHandler
+
+  # return data that needs to be sanitized for BSON
+  # BSON errors if it is sent date/datetime values
+  def run!
+    sani_data = {
+      'date' => Date.today,
+      'datetime' => DateTime.now
+    }
+    nested_sani_data = {
+      'date' => Date.today,
+      'datetime' => DateTime.now
+    }
+    listed_sani_data = {
+      'date' => Date.today,
+      'datetime' => DateTime.now
+    }
+
+    sani_data.merge({
+      'nested' => nested_sani_data,
+      'listed' => [listed_sani_data]
+    })
+  end
+
+end
+
+class SanitzeHaltDataServiceHandler
+  include Sanford::ServiceHandler
+
+  # return data that needs to be sanitized for BSON
+  # BSON errors if it is sent date/datetime values
+  def run!
+    halt 200, 'data' => {
+      'date' => Date.today,
+      'datetime' => DateTime.now
+    }
+  end
+
+end
+
 class FlagServiceHandler
   include Sanford::ServiceHandler
 


### PR DESCRIPTION
BSON fails to serialize on certain data types, specifically Date
and DateTime.  This sanitizes all response datas to prevent BSON
serialization failures.

Note, this assumes a lot on behalf of the user.  Particularly about
how to convent values that need sanitizing.  Plus you incure the
sanitization overhead on _every_ response, whether sanitation is
needed or not.

Meant to address #81 and #82.

@jcredding ready for review.  Like we discussed, I don't love the assumptions and overhead this incurs.  I'm going to do an alternate PR where the test runner just serializes to BSON for you (thereby alerting developers of sanitization errors and then assuming they will go fix them).
