### PR TITLE
test runner now serializes response data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,5 @@ gemspec
 gem 'rake'
 gem 'pry'
 
+gem 'bson'
 gem 'bson_ext', '~>1.7'

--- a/lib/sanford/test_runner.rb
+++ b/lib/sanford/test_runner.rb
@@ -31,7 +31,11 @@ module Sanford
     # want to `run` at all.
 
     def run
-      @response ||= build_response catch_halt{ @handler.run }
+      @response ||= build_response(catch_halt{ @handler.run }).tap do |response|
+        # attempt to serialize (and then throw away) the response data
+        # this will error on the developer if BSON can't serialize their response
+        Sanford::Protocol::BsonBody.new.encode(response.to_hash)
+      end
     end
 
     protected

--- a/test/support/service_handlers.rb
+++ b/test/support/service_handlers.rb
@@ -7,6 +7,19 @@ class BasicServiceHandler
 
 end
 
+class SerializeErrorServiceHandler
+  include Sanford::ServiceHandler
+
+  # return data that fails BSON serialization
+  # BSON errors if it is sent date/datetime values
+  def run!
+    { 'date' => Date.today,
+      'datetime' => DateTime.now
+    }
+  end
+
+end
+
 module CallbackServiceHandler
 
   def self.included(receiver)

--- a/test/unit/service_handler_tests.rb
+++ b/test/unit/service_handler_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'sanford/service_handler'
 
+require 'bson'
 require 'sanford/test_helpers'
 require 'test/support/service_handlers'
 
@@ -241,6 +242,17 @@ module Sanford::ServiceHandler
     should "raise a custom error when initialized in a test" do
       assert_raises Sanford::InvalidServiceHandlerError do
         test_handler(InvalidServiceHandler)
+      end
+    end
+
+  end
+
+  class SerializeErrorTests < UnitTests
+    desc "that failse to serialize to BSON"
+
+    should "raise a BSON error when run in a test" do
+      assert_raises BSON::InvalidDocument do
+        test_runner(SerializeErrorServiceHandler).run
       end
     end
 


### PR DESCRIPTION
This makes for a more robust test.  It will alert devs to serialization
errors in their tests.

This is useful b/c certain versions of BSON error on certain data
types (like `Date` and `DateTime`).  This means your tests can not
only validate the response data itself, but that it will also
serialize.

Closes #81.
Closes #82.

@jcredding ready for review.  We discussed taking this approach as it is less overhead and does less assuming on the part of the users, but still alerts devs to when their response data won't serialize.
