### PR TITLE
allow multiple init procs on host configurations

### DIFF
--- a/lib/sanford/host.rb
+++ b/lib/sanford/host.rb
@@ -27,7 +27,7 @@ module Sanford
       option :receives_keep_alive,          :default => false
       option :runner,                       :default => proc{ Sanford.config.runner }
       option :error_procs,         Array,   :default => []
-      option :init_proc,           Proc,    :default => proc{ }
+      option :init_procs,          Array,   :default => []
 
       def initialize(host)
         self.name = host.class.to_s
@@ -88,7 +88,7 @@ module Sanford
     end
 
     def init(&block)
-      self.configuration.init_proc = block
+      self.configuration.init_procs << block
     end
 
     def service_handler_ns(value = nil)

--- a/lib/sanford/host_data.rb
+++ b/lib/sanford/host_data.rb
@@ -15,7 +15,7 @@ module Sanford
     attr_reader :name, :logger, :verbose, :keep_alive, :runner, :error_procs
 
     def initialize(service_host, options = nil)
-      service_host.configuration.init_proc.call
+      service_host.configuration.init_procs.each(&:call)
 
       overrides = self.remove_nil_values(options || {})
       configuration = service_host.configuration.to_hash.merge(overrides)

--- a/test/unit/host_data_tests.rb
+++ b/test/unit/host_data_tests.rb
@@ -19,7 +19,7 @@ class Sanford::HostData
     should have_readers :name, :logger, :verbose, :keep_alive, :runner, :error_procs
     should have_imeths :handler_class_for, :run
 
-    should "call the setup proc" do
+    should "call the init procs" do
       assert_equal true, TestHost.init_has_been_called
     end
 

--- a/test/unit/host_tests.rb
+++ b/test/unit/host_tests.rb
@@ -66,10 +66,10 @@ module Sanford::Host
       assert_not_empty subject.configuration.error_procs
     end
 
-    should "set the configuration init proc" do
-      assert_nil subject.configuration.init_proc.call
-      subject.init &proc{ 1 }
-      assert_equal 1, subject.configuration.init_proc.call
+    should "add init procs to the configuration" do
+      assert_empty subject.configuration.init_procs
+      subject.init &proc{}
+      assert_not_empty subject.configuration.init_procs
     end
 
     should "get/set its service_handler_ns" do
@@ -117,7 +117,7 @@ module Sanford::Host
     subject{ @configuration }
 
     should have_imeths :name, :ip, :port, :pid_file, :logger, :verbose_logging
-    should have_imeths :receives_keep_alive, :runner, :error_procs, :init_proc
+    should have_imeths :receives_keep_alive, :runner, :error_procs, :init_procs
 
     should "default name to the class name of the host" do
       assert_equal @host_class.name, subject.name
@@ -132,7 +132,7 @@ module Sanford::Host
       assert_false subject.receives_keep_alive
       assert_equal Sanford.config.runner, subject.runner
       assert_empty subject.error_procs
-      assert_kind_of ::Proc, subject.init_proc
+      assert_empty subject.init_procs
     end
 
   end


### PR DESCRIPTION
This switches the host configuation to allow defining multiple
init procs.  Now the `init` method just pushes the proc onto the
configs list of init procs.  On host data init, the host data will
call each init proc in the list.

This is mostly about flexibility and extensibility.  Now multiple
host mixins can each define their own init blocks and add in their
own init behavior, etc.

Closes #83.

@jcredding ready for review.
