### PR TITLE
Allow multiple init and run callbacks using callback DSL

### DIFF
--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -52,11 +52,6 @@ module Sanford
 
       protected
 
-      def before_init; end
-      def after_init;  end
-      def before_run;  end
-      def after_run;   end
-
       # Helpers
 
       def run_handler(handler_class, params = nil)
@@ -69,7 +64,9 @@ module Sanford
       def logger;      @sanford_runner.logger;      end
 
       def run_callback(callback)
-        self.send(callback.to_s)
+        (self.class.send("#{callback}_callbacks") || []).each do |callback|
+          self.instance_eval(&callback)
+        end
       end
 
     end
@@ -78,6 +75,38 @@ module Sanford
 
       def run(params = nil, logger = nil)
         Sanford.config.runner.run(self, params || {}, logger)
+      end
+
+      def before_init(&block)
+        self.before_init_callbacks << block
+      end
+
+      def before_init_callbacks
+        @before_init_callbacks ||= []
+      end
+
+      def after_init(&block)
+        self.after_init_callbacks << block
+      end
+
+      def after_init_callbacks
+        @after_init_callbacks ||= []
+      end
+
+      def before_run(&block)
+        self.before_run_callbacks << block
+      end
+
+      def before_run_callbacks
+        @before_run_callbacks ||= []
+      end
+
+      def after_run(&block)
+        self.after_run_callbacks << block
+      end
+
+      def after_run_callbacks
+        @after_run_callbacks ||= []
       end
 
     end

--- a/test/support/services.rb
+++ b/test/support/services.rb
@@ -76,7 +76,7 @@ class TestHost
   class Authorized
     include Sanford::ServiceHandler
 
-    def before_run
+    before_run do
       halt 401, :message => "Not authorized"
     end
 

--- a/test/unit/service_handler_tests.rb
+++ b/test/unit/service_handler_tests.rb
@@ -11,11 +11,16 @@ module Sanford::ServiceHandler
 
     desc "Sanford::ServiceHandler"
     setup do
-      @handler = test_handler(TestServiceHandler)
+      @handler_class = Class.new{ include Sanford::ServiceHandler }
+      @handler = test_handler(@handler_class)
     end
     subject{ @handler }
 
     should have_cmeths :run
+    should have_cmeths :before_init, :before_init_callbacks
+    should have_cmeths :after_init,  :after_init_callbacks
+    should have_cmeths :before_run,  :before_run_callbacks
+    should have_cmeths :after_run,   :after_run_callbacks
     should have_imeths :init, :init!, :run, :run!
 
     should "raise a NotImplementedError if run! is not overwritten" do
@@ -29,6 +34,34 @@ module Sanford::ServiceHandler
       })
       assert_equal 648,   response.code
       assert_equal true,  response.data
+    end
+
+    should "store procs in #before_init_callbacks with #before_init" do
+      before_init_proc = proc{ }
+      @handler_class.before_init(&before_init_proc)
+
+      assert_includes before_init_proc, @handler_class.before_init_callbacks
+    end
+
+    should "store procs in #after_init_callbacks with #after_init" do
+      after_init_proc = proc{ }
+      @handler_class.after_init(&after_init_proc)
+
+      assert_includes after_init_proc, @handler_class.after_init_callbacks
+    end
+
+    should "store procs in #before_run_callbacks with #before_run" do
+      before_run_proc = proc{ }
+      @handler_class.before_run(&before_run_proc)
+
+      assert_includes before_run_proc, @handler_class.before_run_callbacks
+    end
+
+    should "store procs in #after_run_callbacks with #after_run" do
+      after_run_proc = proc{ }
+      @handler_class.after_run(&after_run_proc)
+
+      assert_includes after_run_proc, @handler_class.after_run_callbacks
     end
 
   end
@@ -49,6 +82,7 @@ module Sanford::ServiceHandler
 
     should "have called `init!` and it's callbacks" do
       assert_true subject.before_init_called
+      assert_true subject.second_before_init_called
       assert_true subject.init_bang_called
       assert_true subject.after_init_called
     end
@@ -57,6 +91,7 @@ module Sanford::ServiceHandler
       assert_nil subject.before_run_called
       assert_nil subject.run_bang_called
       assert_nil subject.after_run_called
+      assert_nil subject.second_after_run_called
     end
 
     should "call `run!` and it's callbacks when it's `run`" do
@@ -65,6 +100,7 @@ module Sanford::ServiceHandler
       assert_true subject.before_run_called
       assert_true subject.run_bang_called
       assert_true subject.after_run_called
+      assert_true subject.second_after_run_called
     end
 
   end


### PR DESCRIPTION
This changes the service handler callbacks for before/after
init/run to use a class level DSL instead of defining the
correctly named method.  This allows defining multiple callback
procs and having them all run.  This is useful when mixins
each add their own callbacks.  Also, with this implementation,
callbacks don't have to worry about `super`ing to make sure all
defined callbacks are run.

Closes #84.

@jcredding ready for review.
