### PR TITLE
prepend callbacks on service handlers

### DIFF
--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -77,37 +77,19 @@ module Sanford
         Sanford.config.runner.run(self, params || {}, logger)
       end
 
-      def before_init(&block)
-        self.before_init_callbacks << block
-      end
+      def before_init_callbacks; @before_init_callbacks ||= []; end
+      def after_init_callbacks;  @after_init_callbacks  ||= []; end
+      def before_run_callbacks;  @before_run_callbacks  ||= []; end
+      def after_run_callbacks;   @after_run_callbacks   ||= []; end
 
-      def before_init_callbacks
-        @before_init_callbacks ||= []
-      end
-
-      def after_init(&block)
-        self.after_init_callbacks << block
-      end
-
-      def after_init_callbacks
-        @after_init_callbacks ||= []
-      end
-
-      def before_run(&block)
-        self.before_run_callbacks << block
-      end
-
-      def before_run_callbacks
-        @before_run_callbacks ||= []
-      end
-
-      def after_run(&block)
-        self.after_run_callbacks << block
-      end
-
-      def after_run_callbacks
-        @after_run_callbacks ||= []
-      end
+      def before_init(&block); self.before_init_callbacks << block; end
+      def after_init(&block);  self.after_init_callbacks  << block; end
+      def before_run(&block);  self.before_run_callbacks  << block; end
+      def after_run(&block);   self.after_run_callbacks   << block; end
+      def prepend_before_init(&block); self.before_init_callbacks.unshift(block); end
+      def prepend_after_init(&block);  self.after_init_callbacks.unshift(block);  end
+      def prepend_before_run(&block);  self.before_run_callbacks.unshift(block);  end
+      def prepend_after_run(&block);   self.after_run_callbacks.unshift(block);   end
 
     end
 


### PR DESCRIPTION
This adds 4 callback DSL methods to the service handlers: prepend_*
for before/after init/run.  The regular methods _append_ callbacks;
these methods _prepend_ callbacks.

Note: I switched to a more "one liner" approach to defining the
callback DSL methods to make it easier to read.  I also reorganized
the tests to make them more robust and explicit.

Closes #94.

@jcredding sorry the diff is rugged - I chose to implement the DSL methods and tests more like we've done it in our big apps - these are just style changes and more explicit testing, but it masks the fact that I am really only adding 4 callback DSL methods and their tests.  Ready for review.
