### PR TITLE
force string names when defining services on hosts

### DIFF
--- a/lib/sanford/host.rb
+++ b/lib/sanford/host.rb
@@ -100,7 +100,7 @@ module Sanford
       if @service_handler_ns && !(handler_class_name =~ /^::/)
         handler_class_name = "#{@service_handler_ns}::#{handler_class_name}"
       end
-      @services[service_name] = handler_class_name
+      @services[service_name.to_s] = handler_class_name
     end
 
     def inspect

--- a/test/support/services.rb
+++ b/test/support/services.rb
@@ -26,7 +26,7 @@ class TestHost
 
   service_handler_ns 'TestHost'
 
-  service 'echo',         'Echo'
+  service :echo,          'Echo'
   service 'bad',          'Bad'
   service 'multiply',     'Multiply'
   service 'halt_it',      '::TestHost::HaltIt'

--- a/test/unit/host_tests.rb
+++ b/test/unit/host_tests.rb
@@ -85,6 +85,12 @@ module Sanford::Host
       assert_equal 'MyNamespace::MyServiceHandler', subject.services['test']
     end
 
+    should "force string names when adding services" do
+      subject.service(:another_service, 'MyServiceHandler')
+      assert_nil subject.services[:another_service]
+      assert_equal 'MyServiceHandler', subject.services['another_service']
+    end
+
     should "ignore a namespace when a service class has leading colons" do
       subject.service_handler_ns 'MyNamespace'
       subject.service('test', '::MyServiceHandler')


### PR DESCRIPTION
This all defined service names to be strings.  This is to avoid
confusing 404 errors when defining as a symbol but calling on the
client with a string.

Note, redding/sanford-protocol similarly forces all requests to
have string names.  This ensures that requests will always be routed
top handlers using string names.

Related to redding/sanford-protocol#22.

@jcredding ready for review.
