### PR TITLE
template engine class for defining custom rendering engines

### DIFF
--- a/lib/sanford/template_engine.rb
+++ b/lib/sanford/template_engine.rb
@@ -1,0 +1,29 @@
+module Sanford
+
+  class TemplateEngine
+
+    attr_reader :opts
+
+    def initialize(opts = nil)
+      @opts = opts || {}
+    end
+
+    def render(path, scope)
+      raise NotImplementedError
+    end
+
+  end
+
+  class NullTemplateEngine < TemplateEngine
+
+    def render(path, scope)
+      template_file = path
+      unless File.exists?(template_file)
+        raise ArgumentError, "template file `#{template_file}` does not exist"
+      end
+      File.read(template_file)
+    end
+
+  end
+
+end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,0 +1,6 @@
+require 'assert/factory'
+
+module Factory
+  extend Assert::Factory
+
+end

--- a/test/support/template.json
+++ b/test/support/template.json
@@ -1,0 +1,1 @@
+This is a json template for use in template engine tests.

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -1,0 +1,63 @@
+require 'assert'
+require 'sanford/template_engine'
+
+require 'test/support/factory'
+
+class Sanford::TemplateEngine
+
+  class UnitTests < Assert::Context
+    desc "Sanford::TemplateEngine"
+    setup do
+      @path = Factory.path
+      @scope = proc{}
+      @engine = Sanford::TemplateEngine.new
+    end
+    subject{ @engine }
+
+    should have_reader :opts
+    should have_imeths :render
+
+    should "default the opts if none given" do
+      exp_opts = {}
+      assert_equal exp_opts, subject.opts
+    end
+
+    should "raise NotImplementedError on `render`" do
+      assert_raises NotImplementedError do
+        subject.render(@path, @scope)
+      end
+    end
+
+  end
+
+  class NullTemplateEngineTests < Assert::Context
+    desc "Sanford::NullTemplateEngine"
+    setup do
+      @engine = Sanford::NullTemplateEngine.new('some' => 'opts')
+    end
+    subject{ @engine }
+
+    should "be a TemplateEngine" do
+      assert_kind_of Sanford::TemplateEngine, subject
+    end
+
+    should "know its opts" do
+      exp_opts = {'some' => 'opts'}
+      assert_equal exp_opts, subject.opts
+    end
+
+    should "read and return the given path on `render" do
+      exists_file = File.join(ROOT, 'test/support/template.json')
+      assert_equal File.read(exists_file), subject.render(exists_file, @scope)
+    end
+
+    should "complain if trying to read a template file that does not exist" do
+      no_exists_file = '/path/to/file'
+      assert_raises ArgumentError do
+        subject.render(no_exists_file, @scope)
+      end
+    end
+
+  end
+
+end


### PR DESCRIPTION
This builds out a basic template engine class to use as a base for
definining custom rendering engines.  These template engines will be
configured on template sources by extension.

This is part of the effort to add template rendering to Sanford.

Note, this bring in assert/factory to setup a basic factory module
for use in testing.

Related to #85.
Related to redding/sanford-rabl#1.
Related to redding/sanford-nm#1.

@jcredding ready for review.
