### PR TITLE
template source class for configuring template sources

### DIFF
--- a/lib/sanford/template_engine.rb
+++ b/lib/sanford/template_engine.rb
@@ -1,11 +1,14 @@
+require 'pathname'
+
 module Sanford
 
   class TemplateEngine
 
-    attr_reader :opts
+    attr_reader :source_path, :opts
 
     def initialize(opts = nil)
       @opts = opts || {}
+      @source_path = Pathname.new(@opts['source_path'].to_s)
     end
 
     def render(path, scope)
@@ -17,7 +20,7 @@ module Sanford
   class NullTemplateEngine < TemplateEngine
 
     def render(path, scope)
-      template_file = path
+      template_file = self.source_path.join(path).to_s
       unless File.exists?(template_file)
         raise ArgumentError, "template file `#{template_file}` does not exist"
       end

--- a/lib/sanford/template_source.rb
+++ b/lib/sanford/template_source.rb
@@ -1,0 +1,22 @@
+require 'sanford/template_engine'
+
+module Sanford
+
+  class TemplateSource
+
+    attr_reader :path, :engines
+
+    def initialize(path)
+      @path = path.to_s
+      @default_opts = { 'source_path' => @path }
+      @engines = Hash.new{ |h,k| Sanford::NullTemplateEngine.new(@default_opts) }
+    end
+
+    def engine(input_ext, engine_class, registered_opts = nil)
+      engine_opts = @default_opts.merge(registered_opts || {})
+      @engines[input_ext.to_s] = engine_class.new(engine_opts)
+    end
+
+  end
+
+end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'sanford/template_engine'
 
+require 'pathname'
 require 'test/support/factory'
 
 class Sanford::TemplateEngine
@@ -8,17 +9,32 @@ class Sanford::TemplateEngine
   class UnitTests < Assert::Context
     desc "Sanford::TemplateEngine"
     setup do
+      @source_path = Factory.path
       @path = Factory.path
       @scope = proc{}
-      @engine = Sanford::TemplateEngine.new
+      @engine = Sanford::TemplateEngine.new('some' => 'opts')
     end
     subject{ @engine }
 
-    should have_reader :opts
+    should have_readers :source_path, :opts
     should have_imeths :render
+
+    should "default its source path" do
+      assert_equal Pathname.new(nil.to_s), subject.source_path
+    end
+
+    should "allow custom source paths" do
+      engine = Sanford::TemplateEngine.new('source_path' => @source_path)
+      assert_equal Pathname.new(@source_path.to_s), engine.source_path
+    end
 
     should "default the opts if none given" do
       exp_opts = {}
+      assert_equal exp_opts, Sanford::TemplateEngine.new.opts
+    end
+
+    should "allow custom opts" do
+      exp_opts = {'some' => 'opts'}
       assert_equal exp_opts, subject.opts
     end
 
@@ -33,7 +49,7 @@ class Sanford::TemplateEngine
   class NullTemplateEngineTests < Assert::Context
     desc "Sanford::NullTemplateEngine"
     setup do
-      @engine = Sanford::NullTemplateEngine.new('some' => 'opts')
+      @engine = Sanford::NullTemplateEngine.new('source_path' => ROOT)
     end
     subject{ @engine }
 
@@ -41,18 +57,14 @@ class Sanford::TemplateEngine
       assert_kind_of Sanford::TemplateEngine, subject
     end
 
-    should "know its opts" do
-      exp_opts = {'some' => 'opts'}
-      assert_equal exp_opts, subject.opts
+    should "read and return the given path in its source path on `render" do
+      exists_file = 'test/support/template.json'
+      exp = File.read(subject.source_path.join(exists_file).to_s)
+      assert_equal exp, subject.render(exists_file, @scope)
     end
 
-    should "read and return the given path on `render" do
-      exists_file = File.join(ROOT, 'test/support/template.json')
-      assert_equal File.read(exists_file), subject.render(exists_file, @scope)
-    end
-
-    should "complain if trying to read a template file that does not exist" do
-      no_exists_file = '/path/to/file'
+    should "complain if given a path that does not exist in its source path" do
+      no_exists_file = '/does/not/exists'
       assert_raises ArgumentError do
         subject.render(no_exists_file, @scope)
       end

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -1,0 +1,58 @@
+require 'assert'
+require 'sanford/template_source'
+
+require 'sanford/template_engine'
+
+class Sanford::TemplateSource
+
+  class UnitTests < Assert::Context
+    desc "Sanford::TemplateSource"
+    setup do
+      @source_path = File.join(ROOT, 'test/support')
+      @source = Sanford::TemplateSource.new(@source_path)
+    end
+    subject{ @source }
+
+    should have_readers :path, :engines
+    should have_imeths :engine
+
+    should "know its path" do
+      assert_equal @source_path.to_s, subject.path
+    end
+
+  end
+
+  class EngineRegistrationTests < UnitTests
+    desc "when registering an engine"
+    setup do
+      @empty_engine = Class.new(Sanford::TemplateEngine) do
+        def render(path, scope); ''; end
+      end
+    end
+
+    should "allow registering new engines" do
+      assert_kind_of Sanford::NullTemplateEngine, subject.engines['empty']
+      subject.engine 'empty', @empty_engine
+      assert_kind_of @empty_engine, subject.engines['empty']
+    end
+
+    should "register with the source path as a default option" do
+      subject.engine 'empty', @empty_engine
+      exp_opts = { 'source_path' => subject.path }
+      assert_equal exp_opts, subject.engines['empty'].opts
+
+      subject.engine 'empty', @empty_engine, 'an' => 'opt'
+      exp_opts = {
+        'source_path' => subject.path,
+        'an' => 'opt'
+      }
+      assert_equal exp_opts, subject.engines['empty'].opts
+
+      subject.engine 'empty', @empty_engine, 'source_path' => 'something'
+      exp_opts = { 'source_path' => 'something' }
+      assert_equal exp_opts, subject.engines['empty'].opts
+    end
+
+  end
+
+end


### PR DESCRIPTION
This is the mechanism that will allow configuring template sources
for Sanford.  This source object is also the place you configure
any custom engines.  Engines are configured on a per-ext basis
and now know about any source path they are created with.

This is part of setting up the render pipeline for sanford.

Related to #85.
Related to redding/sanford-rabl#1.
Related to redding/sanford-nm#1.

@jcredding ready for review
