### PR TITLE
move sanford config and hosts util classes into their own files

### DIFF
--- a/lib/sanford.rb
+++ b/lib/sanford.rb
@@ -1,12 +1,6 @@
-require 'ns-options'
-require 'pathname'
-require 'set'
-
 require 'sanford/version'
-require 'sanford/host'
-require 'sanford/logger'
-require 'sanford/runner'
-require 'sanford/server'
+require 'sanford/config'
+require 'sanford/hosts'
 require 'sanford/service_handler'
 
 ENV['SANFORD_SERVICES_FILE'] ||= 'config/services'
@@ -23,7 +17,7 @@ module Sanford
   end
 
   def self.init
-    @hosts ||= Hosts.new
+    @hosts ||= Sanford::Hosts.new
     require self.config.services_file
   end
 
@@ -33,45 +27,6 @@ module Sanford
 
   def self.hosts
     @hosts
-  end
-
-  module Config
-    include NsOptions::Proxy
-    option :services_file,  Pathname, :default => ENV['SANFORD_SERVICES_FILE']
-    option :logger,                   :default => Sanford::NullLogger.new
-    option :runner,                   :default => Sanford::DefaultRunner
-  end
-
-  class Hosts
-
-    def initialize(values = [])
-      @set = Set.new(values)
-    end
-
-    def method_missing(method, *args, &block)
-      @set.send(method, *args, &block)
-    end
-
-    def respond_to?(method)
-      super || @set.respond_to?(method)
-    end
-
-    # We want class names to take precedence over a configured name, so that if
-    # a user specifies a specific class, they always get it
-    def find(name)
-      find_by_class_name(name) || find_by_name(name)
-    end
-
-    private
-
-    def find_by_class_name(class_name)
-      @set.detect{|host_class| host_class.to_s == class_name.to_s }
-    end
-
-    def find_by_name(name)
-      @set.detect{|host_class| host_class.name == name.to_s }
-    end
-
   end
 
 end

--- a/lib/sanford/cli.rb
+++ b/lib/sanford/cli.rb
@@ -1,4 +1,5 @@
 require 'sanford'
+require 'sanford/manager'
 require 'sanford/version'
 
 module Sanford

--- a/lib/sanford/config.rb
+++ b/lib/sanford/config.rb
@@ -1,0 +1,17 @@
+require 'ns-options'
+require 'pathname'
+require 'sanford/logger'
+require 'sanford/runner'
+
+module Sanford
+
+  module Config
+    include NsOptions::Proxy
+
+    option :services_file,  Pathname, :default => ENV['SANFORD_SERVICES_FILE']
+    option :logger,                   :default => Sanford::NullLogger.new
+    option :runner,                   :default => Sanford::DefaultRunner
+
+  end
+
+end

--- a/lib/sanford/hosts.rb
+++ b/lib/sanford/hosts.rb
@@ -1,0 +1,38 @@
+require 'set'
+require 'sanford/host'
+
+module Sanford
+
+  class Hosts
+
+    def initialize(values = [])
+      @set = Set.new(values)
+    end
+
+    def method_missing(method, *args, &block)
+      @set.send(method, *args, &block)
+    end
+
+    def respond_to?(method)
+      super || @set.respond_to?(method)
+    end
+
+    # We want class names to take precedence over a configured name, so that if
+    # a user specifies a specific class, they always get it
+    def find(name)
+      find_by_class_name(name) || find_by_name(name)
+    end
+
+    private
+
+    def find_by_class_name(class_name)
+      @set.detect{|host_class| host_class.to_s == class_name.to_s }
+    end
+
+    def find_by_name(name)
+      @set.detect{|host_class| host_class.name == name.to_s }
+    end
+
+  end
+
+end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -1,0 +1,20 @@
+require 'assert'
+require 'sanford/config'
+
+require 'ns-options/proxy'
+
+module Sanford::Config
+
+  class UnitTests < Assert::Context
+    desc "Sanford::Config"
+    subject{ Sanford::Config }
+
+    should have_imeths :services_file, :logger, :runner
+
+    should "be an NsOptions::Proxy" do
+      assert_includes NsOptions::Proxy, subject
+    end
+
+  end
+
+end

--- a/test/unit/hosts_tests.rb
+++ b/test/unit/hosts_tests.rb
@@ -1,0 +1,50 @@
+require 'assert'
+require 'sanford/hosts'
+
+require 'sanford/host'
+
+class Sanford::Hosts
+
+  class UnitTests < Assert::Context
+    desc "Sandford::Hosts"
+    setup do
+      @hosts = Sanford::Hosts.new
+    end
+    subject{ @hosts }
+
+    should have_instance_methods :add, :first, :find
+
+  end
+
+  class FindTests < UnitTests
+    desc "find method"
+    setup do
+      @hosts.add ::NotNamedHost
+      @hosts.add ::NamedHost
+      @hosts.add ::BadlyNamedHost
+    end
+
+    should "allow finding hosts by their class name or configured name" do
+      assert_includes ::NotNamedHost, subject
+      assert_includes ::NamedHost, subject
+
+      assert_equal ::NotNamedHost, subject.find('NotNamedHost')
+      assert_equal ::NamedHost, subject.find('NamedHost')
+      assert_equal ::NamedHost, subject.find('named_host')
+    end
+
+    should "prefer hosts with a matching class name over configured name" do
+      assert_includes ::BadlyNamedHost, subject
+      assert_equal NotNamedHost, subject.find('NotNamedHost')
+    end
+
+  end
+
+  # Using this syntax because these classes need to be defined as top-level
+  # constants for ease in using their class names in the tests
+
+  ::NotNamedHost   = Class.new{ include Sanford::Host }
+  ::NamedHost      = Class.new{ include Sanford::Host; name 'named_host' }
+  ::BadlyNamedHost = Class.new{ include Sanford::Host; name 'NotNamedHost' }
+
+end

--- a/test/unit/sanford_tests.rb
+++ b/test/unit/sanford_tests.rb
@@ -1,8 +1,6 @@
 require 'assert'
 require 'sanford'
 
-require 'ns-options/proxy'
-
 module Sanford
 
   class UnitTests < Assert::Context
@@ -12,59 +10,5 @@ module Sanford
     should have_imeths :config, :configure, :init, :register, :hosts
 
   end
-
-  class ConfigTests < UnitTests
-    desc "Config"
-    subject{ Sanford::Config }
-
-    should have_imeths :services_file, :logger, :runner
-
-    should "be an NsOptions::Proxy" do
-      assert_includes NsOptions::Proxy, subject
-    end
-
-  end
-
-  class HostsTests < UnitTests
-    desc "Hosts"
-    setup do
-      @hosts = Sanford::Hosts.new
-    end
-    subject{ @hosts }
-
-    should have_instance_methods :add, :first, :find
-
-  end
-
-  class FindTests < HostsTests
-    desc "find method"
-    setup do
-      @hosts.add ::NotNamedHost
-      @hosts.add ::NamedHost
-      @hosts.add ::BadlyNamedHost
-    end
-
-    should "allow finding hosts by their class name or configured name" do
-      assert_includes ::NotNamedHost, subject
-      assert_includes ::NamedHost, subject
-
-      assert_equal ::NotNamedHost, subject.find('NotNamedHost')
-      assert_equal ::NamedHost, subject.find('NamedHost')
-      assert_equal ::NamedHost, subject.find('named_host')
-    end
-
-    should "prefer hosts with a matching class name over configured name" do
-      assert_includes ::BadlyNamedHost, subject
-      assert_equal NotNamedHost, subject.find('NotNamedHost')
-    end
-
-  end
-
-  # Using this syntax because these classes need to be defined as top-level
-  # constants for ease in using their class names in the tests
-
-  ::NotNamedHost   = Class.new{ include Sanford::Host }
-  ::NamedHost      = Class.new{ include Sanford::Host; name 'named_host' }
-  ::BadlyNamedHost = Class.new{ include Sanford::Host; name 'NotNamedHost' }
 
 end


### PR DESCRIPTION
This is just a reorg of this logic that formalizes it a bit.  This
is prep for adding new features to the config class.  This is also
gets these classes more up to our convention of formalizing logic
like this in its own file.

@jcredding ready for review.  No behavior changes just reorgs.  I'm realizing this "Hosts" set business may be going away once we address #92.  Doesn't really matter right now, just observing this.
