### PR TITLE
configure template source

### DIFF
--- a/lib/sanford.rb
+++ b/lib/sanford.rb
@@ -7,13 +7,9 @@ ENV['SANFORD_SERVICES_FILE'] ||= 'config/services'
 
 module Sanford
 
-  def self.config
-    Sanford::Config
-  end
-
+  def self.config; @config ||= Config.new; end
   def self.configure(&block)
-    self.config.define(&block)
-    self.config
+    block.call(self.config)
   end
 
   def self.init

--- a/lib/sanford/config.rb
+++ b/lib/sanford/config.rb
@@ -2,15 +2,27 @@ require 'ns-options'
 require 'pathname'
 require 'sanford/logger'
 require 'sanford/runner'
+require 'sanford/template_source'
 
 module Sanford
 
-  module Config
+  class Config
     include NsOptions::Proxy
 
-    option :services_file,  Pathname, :default => ENV['SANFORD_SERVICES_FILE']
-    option :logger,                   :default => Sanford::NullLogger.new
-    option :runner,                   :default => Sanford::DefaultRunner
+    option :services_file,  Pathname, :default => proc{ ENV['SANFORD_SERVICES_FILE'] }
+    option :logger,                   :default => proc{ Sanford::NullLogger.new }
+    option :runner,                   :default => proc{ Sanford::DefaultRunner }
+
+    attr_reader :template_source
+
+    def initialize
+      super
+      @template_source = nil
+    end
+
+    def set_template_source(path, &block)
+      @template_source = TemplateSource.new(path).tap{ |s| block.call(s) if block }
+    end
 
   end
 

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -1,18 +1,57 @@
 require 'assert'
 require 'sanford/config'
 
+require 'ns-options/assert_macros'
 require 'ns-options/proxy'
+require 'sanford/logger'
+require 'sanford/runner'
+require 'test/support/factory'
 
-module Sanford::Config
+class Sanford::Config
 
   class UnitTests < Assert::Context
-    desc "Sanford::Config"
-    subject{ Sanford::Config }
+    include NsOptions::AssertMacros
 
-    should have_imeths :services_file, :logger, :runner
+    desc "Sanford::Config"
+    setup do
+      @config = Sanford::Config.new
+    end
+    subject{ @config }
+
+    should have_options :services_file, :logger, :runner
+    should have_readers :template_source
+    should have_imeths :set_template_source
 
     should "be an NsOptions::Proxy" do
-      assert_includes NsOptions::Proxy, subject
+      assert_includes NsOptions::Proxy, subject.class
+    end
+
+    should "default its services file" do
+      exp = Pathname.new(ENV['SANFORD_SERVICES_FILE'])
+      assert_equal exp, subject.services_file
+    end
+
+    should "default its logger to a NullLogger" do
+      assert_kind_of Sanford::NullLogger, subject.logger
+    end
+
+    should "default its runner to a DefaultRunner" do
+      assert_equal Sanford::DefaultRunner, subject.runner
+    end
+
+    should "have no template source by default" do
+      assert_nil subject.template_source
+    end
+
+    should "set a new template source" do
+      path = '/path/to/app/assets'
+      block_called = false
+      subject.set_template_source(path) { |s| block_called = true}
+
+      assert_not_nil subject.template_source
+      assert_kind_of Sanford::TemplateSource, subject.template_source
+      assert_equal path, subject.template_source.path
+      assert_true block_called
     end
 
   end

--- a/test/unit/host_tests.rb
+++ b/test/unit/host_tests.rb
@@ -133,7 +133,7 @@ module Sanford::Host
       assert_equal '0.0.0.0', subject.ip
       assert_nil subject.port
       assert_nil subject.pid_file
-      assert_equal Sanford.config.logger, subject.logger
+      assert_equal Sanford.config.logger.class, subject.logger.class
       assert_true  subject.verbose_logging
       assert_false subject.receives_keep_alive
       assert_equal Sanford.config.runner, subject.runner

--- a/test/unit/sanford_tests.rb
+++ b/test/unit/sanford_tests.rb
@@ -1,6 +1,8 @@
 require 'assert'
 require 'sanford'
 
+require 'sanford/config'
+
 module Sanford
 
   class UnitTests < Assert::Context
@@ -8,6 +10,10 @@ module Sanford
     subject{ Sanford }
 
     should have_imeths :config, :configure, :init, :register, :hosts
+
+    should "return a `Config` instance with the `config` method" do
+      assert_kind_of Sanford::Config, subject.config
+    end
 
   end
 


### PR DESCRIPTION
This updates the config API to allow configuring a template source.
This is part of the effort to add a render pipeline to Sanford.  To
render a template, it needs to exist in a configured source.  Setting
a template source means this source will be used by default in render
calls.

Note, this involved changing the config proxy to a class instance
implementation.  This instance will track the sources.  I also updated
the configs tests to work accordingly and made them more robust.

Related to #85.

@jcredding ready for review.
