### PR TITLE
sanford runner; remove runner configuration

### DIFF
--- a/lib/sanford/config.rb
+++ b/lib/sanford/config.rb
@@ -11,7 +11,6 @@ module Sanford
 
     option :services_file,  Pathname, :default => proc{ ENV['SANFORD_SERVICES_FILE'] }
     option :logger,                   :default => proc{ Sanford::NullLogger.new }
-    option :runner,                   :default => proc{ Sanford::DefaultRunner }
 
     attr_reader :template_source
 

--- a/lib/sanford/host.rb
+++ b/lib/sanford/host.rb
@@ -25,7 +25,6 @@ module Sanford
       option :logger,                       :default => proc{ Sanford.config.logger }
       option :verbose_logging,              :default => true
       option :receives_keep_alive,          :default => false
-      option :runner,                       :default => proc{ Sanford.config.runner }
       option :error_procs,         Array,   :default => []
       option :init_procs,          Array,   :default => []
 
@@ -77,10 +76,6 @@ module Sanford
 
     def receives_keep_alive(*args)
       self.configuration.receives_keep_alive *args
-    end
-
-    def runner(*args)
-      self.configuration.runner *args
     end
 
     def error(&block)

--- a/lib/sanford/host_data.rb
+++ b/lib/sanford/host_data.rb
@@ -1,4 +1,5 @@
 require 'sanford/service_handler'
+require 'sanford/sanford_runner'
 
 module Sanford
 
@@ -12,7 +13,7 @@ module Sanford
     # NOTE: The `name` attribute shouldn't be removed, it is used to identify
     # a `HostData`, particularly in error handlers
 
-    attr_reader :name, :logger, :verbose, :keep_alive, :runner, :error_procs
+    attr_reader :name, :logger, :verbose, :keep_alive, :error_procs
 
     def initialize(service_host, options = nil)
       service_host.configuration.init_procs.each(&:call)
@@ -24,7 +25,6 @@ module Sanford
       @logger      = configuration[:logger]
       @verbose     = configuration[:verbose_logging]
       @keep_alive  = configuration[:receives_keep_alive]
-      @runner      = configuration[:runner]
       @error_procs = configuration[:error_procs]
 
       @handlers = service_host.services.inject({}) do |h, (name, handler_class_name)|
@@ -37,7 +37,7 @@ module Sanford
     end
 
     def run(handler_class, request)
-      self.runner.new(handler_class, request, self.logger).run
+      SanfordRunner.new(handler_class, request, self.logger).run
     end
 
     protected

--- a/lib/sanford/runner.rb
+++ b/lib/sanford/runner.rb
@@ -16,7 +16,7 @@ module Sanford
 
     module InstanceMethods
 
-      attr_reader :handler_class, :request, :logger
+      attr_reader :handler_class, :request, :logger, :handler
 
       def initialize(handler_class, request, logger = nil)
         @handler_class, @request = handler_class, request
@@ -33,8 +33,7 @@ module Sanford
       end
 
       def run
-        response_args = catch_halt{ self.run!(@handler) }
-        Sanford::Protocol::Response.new(response_args.status, response_args.data)
+        build_response catch_halt{ self.run! }
       end
 
       def run!
@@ -56,6 +55,12 @@ module Sanford
         catch(:halt){ ResponseArgs.new(*block.call) }
       end
 
+      protected
+
+      def build_response(args)
+        Sanford::Protocol::Response.new(args.status, args.data) if args
+      end
+
     end
 
     module ClassMethods
@@ -65,16 +70,6 @@ module Sanford
         self.new(handler_class, request, logger).run
       end
 
-    end
-
-  end
-
-  class DefaultRunner
-    include Sanford::Runner
-
-    def run!(handler)
-      handler.init
-      handler.run
     end
 
   end

--- a/lib/sanford/sanford_runner.rb
+++ b/lib/sanford/sanford_runner.rb
@@ -1,0 +1,19 @@
+require 'sanford/runner'
+
+module Sanford
+
+  class SanfordRunner
+    include Sanford::Runner
+
+    # call the handler init and the handler run - if the init halts, run won't
+    # be called.
+
+    def run!
+      self.handler.init
+      response_args = self.handler.run
+      response_args
+    end
+
+  end
+
+end

--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -93,7 +93,7 @@ module Sanford
     module ClassMethods
 
       def run(params = nil, logger = nil)
-        Sanford.config.runner.run(self, params || {}, logger)
+        SanfordRunner.run(self, params || {}, logger)
       end
 
       def before_init_callbacks; @before_init_callbacks ||= []; end

--- a/test/unit/config_tests.rb
+++ b/test/unit/config_tests.rb
@@ -19,7 +19,7 @@ class Sanford::Config
     end
     subject{ @config }
 
-    should have_options :services_file, :logger, :runner
+    should have_options :services_file, :logger
     should have_readers :template_source
     should have_imeths :set_template_source
 
@@ -34,10 +34,6 @@ class Sanford::Config
 
     should "default its logger to a NullLogger" do
       assert_kind_of Sanford::NullLogger, subject.logger
-    end
-
-    should "default its runner to a DefaultRunner" do
-      assert_equal Sanford::DefaultRunner, subject.runner
     end
 
     should "have a null template source by default" do

--- a/test/unit/host_data_tests.rb
+++ b/test/unit/host_data_tests.rb
@@ -14,7 +14,7 @@ class Sanford::HostData
     end
     subject{ @host_data }
 
-    should have_readers :name, :logger, :verbose, :keep_alive, :runner, :error_procs
+    should have_readers :name, :logger, :verbose, :keep_alive, :error_procs
     should have_imeths :handler_class_for, :run
 
     should "call the init procs" do
@@ -26,7 +26,6 @@ class Sanford::HostData
       assert_equal TestHost.configuration.logger.class,        subject.logger.class
       assert_equal TestHost.configuration.verbose_logging,     subject.verbose
       assert_equal TestHost.configuration.receives_keep_alive, subject.keep_alive
-      assert_equal TestHost.configuration.runner.class,        subject.runner.class
       assert_equal TestHost.configuration.error_procs,         subject.error_procs
     end
 

--- a/test/unit/host_tests.rb
+++ b/test/unit/host_tests.rb
@@ -15,7 +15,7 @@ module Sanford::Host
 
     should have_readers :configuration, :services
     should have_imeths :name, :ip, :port, :pid_file, :logger, :verbose_logging
-    should have_imeths :runner, :error, :init, :service_handler_ns, :service
+    should have_imeths :error, :init, :service_handler_ns, :service
 
     should "know its configuration" do
       assert_kind_of Configuration, subject.configuration
@@ -54,10 +54,6 @@ module Sanford::Host
       subject.receives_keep_alive true
       assert_equal true, subject.receives_keep_alive
       assert_equal subject.receives_keep_alive, subject.configuration.receives_keep_alive
-
-      subject.runner Sanford::DefaultRunner
-      assert_equal Sanford::DefaultRunner, subject.runner
-      assert_equal subject.runner, subject.configuration.runner
     end
 
     should "add error procs to the configuration" do
@@ -123,7 +119,7 @@ module Sanford::Host
     subject{ @configuration }
 
     should have_imeths :name, :ip, :port, :pid_file, :logger, :verbose_logging
-    should have_imeths :receives_keep_alive, :runner, :error_procs, :init_procs
+    should have_imeths :receives_keep_alive, :error_procs, :init_procs
 
     should "default name to the class name of the host" do
       assert_equal @host_class.name, subject.name
@@ -136,7 +132,6 @@ module Sanford::Host
       assert_equal Sanford.config.logger.class, subject.logger.class
       assert_true  subject.verbose_logging
       assert_false subject.receives_keep_alive
-      assert_equal Sanford.config.runner, subject.runner
       assert_empty subject.error_procs
       assert_empty subject.init_procs
     end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,37 +1,34 @@
 require 'assert'
 require 'sanford/runner'
 
+require 'test/support/service_handlers'
+
 module Sanford::Runner
 
   class UnitTests < Assert::Context
     desc "Sanford::Runner"
     setup do
       request = Sanford::Protocol::Request.new('test', {})
-      @runner = Sanford::DefaultRunner.new(BasicServiceHandler, request)
+      @runner_class = Class.new do
+        include Sanford::Runner
+      end
+      @runner = @runner_class.new(BasicServiceHandler, request)
     end
     subject{ @runner }
 
     should have_cmeths :run
-    should have_readers :handler_class, :request, :logger, :run
+    should have_readers :handler_class, :request, :logger, :handler
+    should have_imeths :init, :init!, :run, :run!
+    should have_imeths :halt, :catch_halt
 
-    should "run the handler and return the response it generates when `run` is called" do
-      response = subject.run
-
-      assert_instance_of Sanford::Protocol::Response, response
-      assert_equal 200,                     response.code
-      assert_equal 'Joe Test',              response.data['name']
-      assert_equal 'joe.test@example.com',  response.data['email']
-    end
-
-    should "be able to build a runner with a handler class and params" do
-      response = nil
-      assert_nothing_raised do
-        response = Sanford::DefaultRunner.run(BasicServiceHandler, {})
+    should "not implement the run behavior" do
+      assert_raises NotImplementedError do
+        subject.run
       end
-
-      assert_equal 200, response.code
     end
 
   end
+
+  # runner behavior tests are handled via system tests
 
 end

--- a/test/unit/sanford_runner_tests.rb
+++ b/test/unit/sanford_runner_tests.rb
@@ -1,0 +1,52 @@
+require 'assert'
+require 'sanford/sanford_runner'
+
+require 'sanford/runner'
+require 'test/support/service_handlers'
+
+class Sanford::SanfordRunner
+
+  class UnitTests < Assert::Context
+    desc "Sanford::SanfordRunner"
+    setup do
+      @runner_class = Sanford::SanfordRunner
+    end
+    subject{ @runner_class }
+
+    should "be a Runner" do
+      assert_includes Sanford::Runner, subject
+    end
+
+    should "be able to build a runner with a handler class and params and run it" do
+      response = nil
+      assert_nothing_raised do
+        response = subject.run(BasicServiceHandler, {})
+      end
+
+      assert_equal 200, response.code
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      request = Sanford::Protocol::Request.new('test', {})
+      @runner = @runner_class.new(BasicServiceHandler, request)
+    end
+    subject{ @runner }
+
+    should "run the handler and return the response it generates when `run` is called" do
+      response = subject.run
+
+      assert_instance_of Sanford::Protocol::Response, response
+      assert_equal 200, response.code
+      assert_equal 'Joe Test', response.data['name']
+      assert_equal 'joe.test@example.com',  response.data['email']
+    end
+
+  end
+
+  # live runner behavior tests are handled via system tests
+
+end


### PR DESCRIPTION
This removes the concept of a default runner and configuring runners
on hosts.  Instead, there is now only a `SanfordRunner`, which hosts
use to run their handlers, and a `TestRunner` which you use to run
handlers in tests.  The sanford runner is basically equivalent to
what the default runner was before.

I think it unnecessary overhead to provide runner configuration to
customize runner behavior.  Anytime you wish to customize the runner,
you have to be sure to do everything the default runner was doing and
then keep that in sync.

Intead, the runner should provide hooks to add custom behavior.  This
gets the benefit of just having to maintain what is custom and not
what should be default.

In a coming PR, I'll be adding handler callbacks that only the default
runner will call.  This will be the place to customize runner behavior
on a per-handler basis.  This is setup for that work.

Related to #102.

@jcredding like we discussed - trying to move to more of the pattern Deas uses (with its `SinatraRunner` and callbacks).  Ready for review.
