### PR TITLE
`before` and `after` handler callbacks

### DIFF
--- a/lib/sanford/host.rb
+++ b/lib/sanford/host.rb
@@ -106,7 +106,7 @@ module Sanford
 
     module ClassMethods
 
-      # the class level of a `Host` should just proxy it's methods down to it's
+      # the class level of a `Host` should just proxy its methods down to its
       # instance (it's a `Singleton`)
 
       # `name` is defined by all objects, so we can't rely on `method_missing`

--- a/lib/sanford/sanford_runner.rb
+++ b/lib/sanford/sanford_runner.rb
@@ -9,9 +9,17 @@ module Sanford
     # be called.
 
     def run!
+      run_callbacks self.handler_class.before_callbacks
       self.handler.init
       response_args = self.handler.run
+      run_callbacks self.handler_class.after_callbacks
       response_args
+    end
+
+    private
+
+    def run_callbacks(callbacks)
+      callbacks.each{|proc| self.handler.instance_eval(&proc) }
     end
 
   end

--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -89,7 +89,7 @@ module Sanford
       # packetizes our stream. This improves both latency and throughput.
       # TCP_CORK disables Nagle's algorithm, which is ideal for sporadic
       # traffic (like Telnet) but is less optimal for HTTP. Sanford is similar
-      # to HTTP, it doesn't receive sporadic packets, it has all it's data
+      # to HTTP, it doesn't receive sporadic packets, it has all its data
       # come in at once.
       # For more information: http://baus.net/on-tcp_cork
 

--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -96,15 +96,22 @@ module Sanford
         SanfordRunner.run(self, params || {}, logger)
       end
 
+      def before_callbacks;      @before_callbacks      ||= []; end
+      def after_callbacks;       @after_callbacks       ||= []; end
       def before_init_callbacks; @before_init_callbacks ||= []; end
       def after_init_callbacks;  @after_init_callbacks  ||= []; end
       def before_run_callbacks;  @before_run_callbacks  ||= []; end
       def after_run_callbacks;   @after_run_callbacks   ||= []; end
 
+      def before(&block);      self.before_callbacks      << block; end
+      def after(&block);       self.after_callbacks       << block; end
       def before_init(&block); self.before_init_callbacks << block; end
       def after_init(&block);  self.after_init_callbacks  << block; end
       def before_run(&block);  self.before_run_callbacks  << block; end
       def after_run(&block);   self.after_run_callbacks   << block; end
+
+      def prepend_before(&block);      self.before_callbacks.unshift(block);      end
+      def prepend_after(&block);       self.after_callbacks.unshift(block);       end
       def prepend_before_init(&block); self.before_init_callbacks.unshift(block); end
       def prepend_after_init(&block);  self.after_init_callbacks.unshift(block);  end
       def prepend_before_run(&block);  self.before_run_callbacks.unshift(block);  end

--- a/test/support/service_handlers.rb
+++ b/test/support/service_handlers.rb
@@ -24,9 +24,17 @@ module CallbackServiceHandler
 
   def self.included(receiver)
     receiver.class_eval do
+      attr_reader :before_called, :after_called
       attr_reader :before_init_called, :init_bang_called, :after_init_called
       attr_reader :before_run_called, :run_bang_called, :after_run_called
       attr_reader :second_before_init_called, :second_after_run_called
+
+      before do
+        @before_called = true
+      end
+      after do
+        @after_called = true
+      end
 
       before_init do
         @before_init_called = true

--- a/test/system/request_handling_tests.rb
+++ b/test/system/request_handling_tests.rb
@@ -251,7 +251,7 @@ class RequestHandlingTests < Assert::Context
     end
   end
 
-  # Sending the server a protocol version that doesn't match it's version
+  # Sending the server a protocol version that doesn't match its version
   class WrongProtocolVersionTests < ForkedServerTests
     desc "when sent a request with a wrong protocol version"
 

--- a/test/unit/manager_tests.rb
+++ b/test/unit/manager_tests.rb
@@ -112,7 +112,7 @@ module Sanford::Manager
 
     should have_imeths :pid, :to_s, :write, :remove
 
-    should "return it's path with #to_s" do
+    should "return its path with #to_s" do
       assert_equal @pid_file_path, subject.to_s
     end
 

--- a/test/unit/sanford_runner_tests.rb
+++ b/test/unit/sanford_runner_tests.rb
@@ -31,18 +31,32 @@ class Sanford::SanfordRunner
   class InitTests < UnitTests
     desc "when init"
     setup do
-      request = Sanford::Protocol::Request.new('test', {})
-      @runner = @runner_class.new(BasicServiceHandler, request)
+      @request = Sanford::Protocol::Request.new('test', {})
+      @runner = @runner_class.new(BasicServiceHandler, @request)
     end
     subject{ @runner }
 
-    should "run the handler and return the response it generates when `run` is called" do
+    should "run the handler and return the response it generates when run" do
       response = subject.run
 
       assert_instance_of Sanford::Protocol::Response, response
       assert_equal 200, response.code
       assert_equal 'Joe Test', response.data['name']
       assert_equal 'joe.test@example.com',  response.data['email']
+    end
+
+  end
+
+  class CallbackTests < InitTests
+    setup do
+      @runner = @runner_class.new(FlagServiceHandler, @request)
+    end
+
+    should "call handler `before` and `after` callbacks when run" do
+      subject.run
+
+      assert_true subject.handler.before_called
+      assert_true subject.handler.after_called
     end
 
   end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -17,7 +17,7 @@ class Sanford::Server
       assert_includes DatTCP::Server, subject.class
     end
 
-    should "save it's host and host options but not initialize a host data yet" do
+    should "save its host and host options but not initialize a host data yet" do
       assert_equal TestHost, subject.sanford_host
       assert_equal true, subject.sanford_host_options[:receives_keep_alive]
       assert_nil subject.sanford_host_data


### PR DESCRIPTION
This adds support for before and after handler callbacks.  The
difference between these and their *_init/run counterparts is that
these callbacks are intended to be run by the runner - specifically
only the SanfordRunner.

Use the normal callbacks if you want to add specific handler behavior
and need to test it.  These callbacks are meant more to customize the
behavior of `SanfordRunner` (since you can no longer configure your
own runner).  It is important to remember that these callbacks are not
run by the test runner.

Closes #102.

@jcredding ready for review.
