### PR TITLE
Add `Router` and `Route` for routing and running services

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', '~> 0.9.0'
 
 gem 'bson_ext'

--- a/lib/sanford/route.rb
+++ b/lib/sanford/route.rb
@@ -1,0 +1,48 @@
+require 'sanford/sanford_runner'
+
+module Sanford
+
+  class Route
+
+    attr_reader :name, :handler_class_name, :handler_class
+
+    def initialize(name, handler_class_name)
+      @name = name.to_s
+      @handler_class_name = handler_class_name
+      @handler_class = nil
+    end
+
+    def validate!
+      @handler_class = constantize_handler_class(@handler_class_name)
+    end
+
+    def run(request, logger)
+      SanfordRunner.new(self.handler_class, request, logger).run
+    end
+
+    private
+
+    def constantize_handler_class(handler_class_name)
+      constantize(handler_class_name).tap do |handler_class|
+        raise(NoHandlerClassError.new(handler_class_name)) if !handler_class
+      end
+    end
+
+    def constantize(class_name)
+      names = class_name.to_s.split('::').reject{ |name| name.empty? }
+      klass = names.inject(Object){ |constant, name| constant.const_get(name) }
+      klass == Object ? false : klass
+    rescue NameError
+      false
+    end
+
+  end
+
+  class NoHandlerClassError < RuntimeError
+    def initialize(handler_class_name)
+      super "Sanford couldn't find the service handler '#{handler_class_name}'" \
+            " - it doesn't exist or hasn't been required in yet."
+    end
+  end
+
+end

--- a/lib/sanford/router.rb
+++ b/lib/sanford/router.rb
@@ -1,0 +1,36 @@
+require 'sanford/route'
+
+module Sanford
+
+  class Router
+
+    attr_reader :routes
+
+    def initialize(&block)
+      @service_handler_ns = nil
+      @routes = []
+      self.instance_eval(&block) if !block.nil?
+    end
+
+    def service_handler_ns(value = nil)
+      @view_handler_ns = value if !value.nil?
+      @view_handler_ns
+    end
+
+    def service(name, handler_name)
+      if self.service_handler_ns && !(handler_name =~ /^::/)
+        handler_name = "#{self.service_handler_ns}::#{handler_name}"
+      end
+
+      @routes.push(Sanford::Route.new(name, handler_name))
+    end
+
+    def inspect
+      reference = '0x0%x' % (self.object_id << 1)
+      "#<#{self.class}:#{reference} " \
+        "@service_handler_ns=#{self.service_handler_ns.inspect}>"
+    end
+
+  end
+
+end

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -1,0 +1,93 @@
+require 'assert'
+require 'sanford/route'
+
+require 'sanford/service_handler'
+
+class Sanford::Route
+
+  class UnitTests < Assert::Context
+    desc "Sanford::Route"
+    setup do
+      @name = Factory.string
+      @handler_class_name = TestHandler.to_s
+      @route = Sanford::Route.new(@name, @handler_class_name)
+    end
+    subject{ @route }
+
+    should have_readers :name, :handler_class_name, :handler_class
+
+    should "know its name and handler class name" do
+      assert_equal @name, subject.name
+      assert_equal @handler_class_name, subject.handler_class_name
+    end
+
+    should "not know its handler class by default" do
+      assert_nil subject.handler_class
+    end
+
+    should "constantize its handler class after being validated" do
+      subject.validate!
+      assert_equal TestHandler, subject.handler_class
+    end
+
+  end
+
+  class RunTests < UnitTests
+    desc "when run"
+    setup do
+      @route.validate!
+      @request = Factory.string
+      @logger  = Factory.string
+
+      @runner_spy = RunnerSpy.new(Factory.text)
+      Sanford::SanfordRunner.stubs(:new).tap do |s|
+        s.with(@route.handler_class, @request, @logger)
+        s.returns(@runner_spy)
+      end
+
+      @response = @route.run(@request, @logger)
+    end
+    teardown do
+      Sanford::SanfordRunner.unstub(:new)
+    end
+    subject{ @response }
+
+    should "build and run a sanford runner" do
+      assert_true @runner_spy.run_called
+    end
+
+    should "return the response from the running the runner" do
+      assert_equal @runner_spy.response, subject
+    end
+
+  end
+
+  class InvalidHandlerClassNameTests < UnitTests
+    desc "with an invalid handler class name"
+    setup do
+      @route = Sanford::Route.new(@name, Factory.string)
+    end
+
+    should "raise a no handler class error when validated" do
+      assert_raises(Sanford::NoHandlerClassError){ subject.validate! }
+    end
+
+  end
+
+  TestHandler = Class.new
+
+  class RunnerSpy
+    attr_reader :response, :run_called
+
+    def initialize(response)
+      @response = response
+      @run_called = false
+    end
+
+    def run
+      @run_called = true
+      @response
+    end
+  end
+
+end

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -1,0 +1,65 @@
+require 'assert'
+require 'sanford/router'
+
+require 'test/support/factory'
+
+class Sanford::Router
+
+  class UnitTests < Assert::Context
+    desc "Sanford::Host"
+    setup do
+      @router = Sanford::Router.new
+    end
+    subject{ @router }
+
+    should have_readers :routes
+    should have_imeths :service_handler_ns, :service
+
+    should "build an empty array for its routes by default" do
+      assert_equal [], subject.routes
+    end
+
+    should "not have a service handler ns by default" do
+      assert_nil subject.service_handler_ns
+    end
+
+    should "allow setting its service handler ns" do
+      namespace = Factory.string
+      subject.service_handler_ns namespace
+      assert_equal namespace, subject.service_handler_ns
+    end
+
+    should "allow adding routes using `service`" do
+      service_name = Factory.string
+      handler_name = Factory.string
+      subject.service service_name, handler_name
+
+      route = subject.routes.last
+      assert_instance_of Sanford::Route, route
+      assert_equal service_name, route.name
+      assert_equal handler_name, route.handler_class_name
+    end
+
+    should "use its service handler ns when adding routes" do
+      namespace = Factory.string
+      subject.service_handler_ns namespace
+
+      service_name = Factory.string
+      handler_name = Factory.string
+      subject.service service_name, handler_name
+
+      route = subject.routes.last
+      expected = "#{namespace}::#{handler_name}"
+      assert_equal expected, route.handler_class_name
+    end
+
+    should "know its custom inspect" do
+      reference = '0x0%x' % (subject.object_id << 1)
+      expected = "#<#{subject.class}:#{reference} " \
+                   "@service_handler_ns=#{subject.service_handler_ns.inspect}>"
+      assert_equal expected, subject.inspect
+    end
+
+  end
+
+end


### PR DESCRIPTION
This adds a `Router` and `Route` class. The `Router` will replace
part of the `Host` and `HostData` logic for routing services. This
also adds a `Route` class that will be built when a service is
added to the router. This will handler building and running a
`SanfordRunner` and returning the response. This follows Deas'
implementation and is part of the effort to modify Sanford's
configuration and startup logic.

@kellyredding - Ready for review.
