### PR TITLE
switch to the latest assert for test stubbing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,6 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'pry'
+gem 'pry', "~> 0.9.0"
 
 gem 'bson_ext'

--- a/sanford.gemspec
+++ b/sanford.gemspec
@@ -18,10 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("dat-tcp",           ["~> 0.4"])
-  gem.add_dependency("ns-options",        ["~> 1.1"])
-  gem.add_dependency("sanford-protocol",  ["~> 0.8"])
+  gem.add_dependency("dat-tcp",          ["~> 0.4"])
+  gem.add_dependency("ns-options",       ["~> 1.1"])
+  gem.add_dependency("sanford-protocol", ["~> 0.8"])
 
-  gem.add_development_dependency("assert",        ["~> 2.10"])
-  gem.add_development_dependency("assert-mocha",  ["~> 1.1"])
+  gem.add_development_dependency("assert", ["~> 2.11"])
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -5,7 +5,6 @@
 $LOAD_PATH.unshift(File.expand_path("../..", __FILE__))
 
 require 'pry' # require pry for debugging (`binding.pry`)
-require 'assert-mocha' if defined?(Assert)
 
 ENV['SANFORD_PROTOCOL_DEBUG'] = 'yes'
 

--- a/test/system/request_handling_tests.rb
+++ b/test/system/request_handling_tests.rb
@@ -199,10 +199,7 @@ class RequestHandlingTests < Assert::Context
       @server.on_run
       @socket = Sanford::Protocol::FakeSocket.new
       @fake_connection = FakeProtocolConnection.new(@socket)
-      Sanford::Protocol::Connection.stubs(:new).with(@socket).returns(@fake_connection)
-    end
-    teardown do
-      Sanford::Protocol::Connection.unstub(:new)
+      Assert.stub(Sanford::Protocol::Connection, :new).with(@socket){ @fake_connection }
     end
 
     should "not error and nothing should be written" do


### PR DESCRIPTION
The latest assert adds its own native stubbing API. The switches
to that. No behavior changes - just test cleanups.

@jcredding ready for review.
