### PR TITLE
Update to use the new DatTCP, rename server to server old

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gem 'rake'
 gem 'pry', "~> 0.9.0"
 
 gem 'bson_ext'
+
+gem 'dat-tcp', :path => "~/Projects/redding/gems/dat-tcp/"

--- a/bench/client.rb
+++ b/bench/client.rb
@@ -10,11 +10,11 @@ module Bench
       @host, @port = [ host, port ]
     end
 
-    def call(version, name, params)
+    def call(name, params)
       socket = TCPSocket.open(@host, @port)
       socket.setsockopt(Socket::IPPROTO_TCP, Socket::TCP_NODELAY, true) # TODO - explain
       connection = Sanford::Protocol::Connection.new(socket)
-      request = Sanford::Protocol::Request.new(version, name, params)
+      request = Sanford::Protocol::Request.new(name, params)
       connection.write(request.to_hash)
       connection.close_write
       if IO.select([ socket ], nil, nil, 10)

--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,40 +2,33 @@ Running benchmark report...
 
 Hitting "simple" service with {}, 10000 times
 ....................................................................................................
-Total Time:   8970.7162ms
-Average Time:    0.8970ms
-Min Time:        0.5419ms
-Max Time:      108.7779ms
+Total Time:   5753.9772ms
+Average Time:    0.5753ms
+Min Time:        0.3659ms
+Max Time:       32.6111ms
 
 Distribution (number of requests):
-  0ms: 9634
-    0.5ms: 2063
-    0.6ms: 5113
-    0.7ms: 1448
-    0.8ms: 675
-    0.9ms: 335
-  1ms: 319
-    1.0ms: 129
-    1.1ms: 67
-    1.2ms: 44
-    1.3ms: 20
-    1.4ms: 23
-    1.5ms: 11
-    1.6ms: 13
-    1.7ms: 1
-    1.8ms: 6
-    1.9ms: 5
-  2ms: 11
-  3ms: 9
-  4ms: 4
-  5ms: 1
-  21ms: 1
-  87ms: 1
-  90ms: 1
-  97ms: 5
-  98ms: 9
-  99ms: 2
-  100ms: 2
-  108ms: 1
+  0ms: 9931
+    0.3ms: 2599
+    0.4ms: 5820
+    0.5ms: 724
+    0.6ms: 431
+    0.7ms: 226
+    0.8ms: 108
+    0.9ms: 23
+  1ms: 27
+    1.0ms: 4
+    1.1ms: 8
+    1.2ms: 7
+    1.3ms: 5
+    1.4ms: 2
+    1.6ms: 1
+  10ms: 1
+  13ms: 1
+  25ms: 1
+  29ms: 6
+  30ms: 22
+  31ms: 9
+  32ms: 2
 
 Done running benchmark report

--- a/lib/sanford/manager.rb
+++ b/lib/sanford/manager.rb
@@ -1,5 +1,5 @@
 require 'sanford/cli'
-require 'sanford/server'
+require 'sanford/server_old'
 
 module Sanford
 
@@ -123,7 +123,7 @@ module Sanford
 
       def run!(daemonize = false)
         daemonize!(true) if daemonize && !ENV['SANFORD_SKIP_DAEMONIZE']
-        Sanford::Server.new(@host, @server_options).tap do |server|
+        Sanford::ServerOld.new(@host, @server_options).tap do |server|
           log "Starting #{@host.name} server..."
 
           server.listen(*@config.listen_args)
@@ -137,7 +137,7 @@ module Sanford
           Signal.trap("INT"){  self.halt!(server) }
           Signal.trap("USR2"){ self.restart!(server) }
 
-          server_thread = server.run(@config.client_file_descriptors)
+          server_thread = server.start(@config.client_file_descriptors)
           log "#{@host.name} server started and ready."
           server_thread.join
         end

--- a/sanford.gemspec
+++ b/sanford.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("dat-tcp",          ["~> 0.4"])
+  gem.add_dependency("dat-tcp",          ["~> 0.5"])
   gem.add_dependency("ns-options",       ["~> 1.1"])
   gem.add_dependency("sanford-protocol", ["~> 0.8"])
 

--- a/test/support/helpers.rb
+++ b/test/support/helpers.rb
@@ -3,9 +3,9 @@ module Test
 
     def start_server(host, &block)
       begin
-        server = Sanford::Server.new(host, { :ready_timeout => 0.1 })
+        server = Sanford::ServerOld.new(host, { :ready_timeout => 0.1 })
         server.listen(host.ip, host.port)
-        thread = server.run
+        thread = server.start
         yield
       ensure
         server.halt if server

--- a/test/system/request_handling_tests.rb
+++ b/test/system/request_handling_tests.rb
@@ -1,4 +1,7 @@
 require 'assert'
+require 'sanford'
+require 'sanford/server_old'
+
 require 'sanford-protocol/fake_socket'
 
 # These tests are intended as a high level test against Sanford's server. They
@@ -192,7 +195,7 @@ class RequestHandlingTests < Assert::Context
   class WithAKeepAliveTests < FakeConnectionTests
     desc "receiving a keep-alive connection"
     setup do
-      @server = Sanford::Server.new(TestHost, {
+      @server = Sanford::ServerOld.new(TestHost, {
         :ready_timeout => 0.1,
         :keep_alive    => true
       })

--- a/test/unit/server_old_tests.rb
+++ b/test/unit/server_old_tests.rb
@@ -1,21 +1,18 @@
 require 'assert'
-require 'sanford/server'
+require 'sanford/server_old'
 
-class Sanford::Server
+class Sanford::ServerOld
 
   class UnitTests < Assert::Context
-    desc "Sanford::Server"
+    desc "Sanford::ServerOld"
     setup do
-      @server = Sanford::Server.new(TestHost, :keep_alive => true)
+      @server = Sanford::ServerOld.new(TestHost, :keep_alive => true)
     end
     subject{ @server }
 
     should have_readers :sanford_host, :sanford_host_data, :sanford_host_options
-    should have_imeths :on_run
-
-    should "include DatTCP::Server" do
-      assert_includes DatTCP::Server, subject.class
-    end
+    should have_imeths :on_run, :ip, :port
+    should have_imeths :listen, :start, :stop, :halt
 
     should "save its host and host options but not initialize a host data yet" do
       assert_equal TestHost, subject.sanford_host
@@ -29,7 +26,7 @@ class Sanford::Server
     desc "run"
     setup do
       @server.listen(TestHost.ip, TestHost.port)
-      @server.run
+      @server.start
     end
     teardown do
       @server.stop
@@ -41,7 +38,7 @@ class Sanford::Server
 
   end
 
-  # Sanford::Server#serve is tested in test/system/request_handling_test.rb,
+  # Sanford::ServerOld#serve is tested in test/system/request_handling_test.rb,
   # it requires multiple parts of Sanford and basically tests a large portion of
   # the entire system
 


### PR DESCRIPTION
This updates Sanford to work with the latest DatTCP but also
renames server to server old. This is done to make room for
reworking the server without breaking sanfords full functionality.
Until we are ready to switch to the new server logic, the old
logic can continue to be function. This switches to using the
new DatTCP with leaving the server logic as unchanged as possible.
This doesn't change any functionality, just switches out to the
new DatTCP and renames the server.

@kellyredding - Ready for review.
