### PR TITLE
Add `Server::ConfigData`, make `HostData` compatible

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,33 +2,35 @@ Running benchmark report...
 
 Hitting "simple" service with {}, 10000 times
 ....................................................................................................
-Total Time:   5753.9772ms
-Average Time:    0.5753ms
-Min Time:        0.3659ms
-Max Time:       32.6111ms
+Total Time:   5532.3838ms
+Average Time:    0.5532ms
+Min Time:        0.3569ms
+Max Time:       74.6099ms
 
 Distribution (number of requests):
-  0ms: 9931
-    0.3ms: 2599
-    0.4ms: 5820
-    0.5ms: 724
-    0.6ms: 431
-    0.7ms: 226
-    0.8ms: 108
-    0.9ms: 23
-  1ms: 27
-    1.0ms: 4
-    1.1ms: 8
-    1.2ms: 7
-    1.3ms: 5
-    1.4ms: 2
-    1.6ms: 1
-  10ms: 1
+  0ms: 9942
+    0.3ms: 3893
+    0.4ms: 5371
+    0.5ms: 474
+    0.6ms: 108
+    0.7ms: 70
+    0.8ms: 19
+    0.9ms: 7
+  1ms: 16
+    1.0ms: 6
+    1.1ms: 3
+    1.2ms: 5
+    1.3ms: 1
+    1.5ms: 1
   13ms: 1
-  25ms: 1
-  29ms: 6
-  30ms: 22
-  31ms: 9
-  32ms: 2
+  15ms: 1
+  27ms: 1
+  28ms: 2
+  29ms: 26
+  30ms: 7
+  32ms: 1
+  39ms: 1
+  54ms: 1
+  74ms: 1
 
 Done running benchmark report

--- a/lib/sanford/error_handler.rb
+++ b/lib/sanford/error_handler.rb
@@ -5,12 +5,12 @@ module Sanford
 
   class ErrorHandler
 
-    attr_reader :exception, :host_data, :request
+    attr_reader :exception, :config_data, :request
+    attr_reader :error_procs
 
-    def initialize(exception, host_data = nil, request = nil)
-      @exception, @host_data, @request = exception, host_data, request
-      @keep_alive  = @host_data ? @host_data.keep_alive : false
-      @error_procs = @host_data ? @host_data.error_procs.reverse : []
+    def initialize(exception, config_data = nil, request = nil)
+      @exception, @config_data, @request = exception, config_data, request
+      @error_procs = @config_data ? @config_data.error_procs.reverse : []
     end
 
     # The exception that we are generating a response for can change in the case
@@ -24,8 +24,8 @@ module Sanford
       @error_procs.each do |error_proc|
         result = nil
         begin
-          result = error_proc.call(@exception, @host_data, @request)
-        rescue Exception => proc_exception
+          result = error_proc.call(@exception, @config_data, @request)
+        rescue StandardError => proc_exception
           @exception = proc_exception
         end
         response ||= self.response_from_proc(result)

--- a/lib/sanford/host_data.rb
+++ b/lib/sanford/host_data.rb
@@ -13,7 +13,10 @@ module Sanford
     # NOTE: The `name` attribute shouldn't be removed, it is used to identify
     # a `HostData`, particularly in error handlers
 
-    attr_reader :name, :logger, :verbose, :keep_alive, :error_procs
+    attr_reader :name
+    attr_reader :logger, :verbose_logging
+    attr_reader :error_procs
+    attr_reader :receives_keep_alive
 
     def initialize(service_host, options = nil)
       service_host.configuration.init_procs.each(&:call)
@@ -21,10 +24,10 @@ module Sanford
       overrides = self.remove_nil_values(options || {})
       configuration = service_host.configuration.to_hash.merge(overrides)
 
-      @name        = configuration[:name]
-      @logger      = configuration[:logger]
-      @verbose     = configuration[:verbose_logging]
-      @keep_alive  = configuration[:receives_keep_alive]
+      @name = configuration[:name]
+      @logger = configuration[:logger]
+      @verbose_logging = configuration[:verbose_logging]
+      @receives_keep_alive  = configuration[:receives_keep_alive]
       @error_procs = configuration[:error_procs]
 
       @handlers = service_host.services.inject({}) do |h, (name, handler_class_name)|

--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -17,6 +17,13 @@ module Sanford
 
     module InstanceMethods
 
+      attr_reader :config_data
+
+      def initialize
+        self.class.configuration.validate!
+        @config_data = ConfigData.new(self.class.configuration.to_hash)
+      end
+
     end
 
     module ClassMethods
@@ -72,6 +79,39 @@ module Sanford
 
     end
 
+    class ConfigData
+      # The server uses this to "compile" the configuration data for speed.
+      # NsOptions is relatively slow everytime an option is read. To avoid this,
+      # we read the options one time here and memoize their values. This way,
+      # we don't pay the NsOptions overhead when reading them while handling
+      # a request.
+
+      attr_reader :name
+      attr_reader :ip, :port
+      attr_reader :logger, :verbose_logging
+      attr_reader :receives_keep_alive
+      attr_reader :error_procs
+      attr_reader :routes
+
+      def initialize(args = nil)
+        args ||= {}
+        @name = args[:name]
+        @ip   = args[:ip]
+        @port = args[:port]
+        @logger = args[:logger]
+        @verbose_logging = !!args[:verbose_logging]
+        @receives_keep_alive = !!args[:receives_keep_alive]
+        @error_procs = args[:error_procs] || []
+        @routes = (args[:routes] || []).inject({}) do |h, route|
+          h.merge(route.name => route)
+        end
+      end
+
+      def route_for(name)
+        @routes[name] || raise(NotFoundError, "no service named '#{name}'")
+      end
+    end
+
     class Configuration
       include NsOptions::Proxy
 
@@ -116,9 +156,10 @@ module Sanford
         self.routes.each(&:validate!)
         @valid = true
       end
-
     end
 
   end
+
+  NotFoundError = Class.new(RuntimeError)
 
 end

--- a/lib/sanford/server_old.rb
+++ b/lib/sanford/server_old.rb
@@ -76,7 +76,7 @@ module Sanford
     protected
 
     def keep_alive_connection?(connection)
-      @sanford_host_data.keep_alive && connection.peek_data.empty?
+      @sanford_host_data.receives_keep_alive && connection.peek_data.empty?
     end
 
     class Connection

--- a/lib/sanford/worker.rb
+++ b/lib/sanford/worker.rb
@@ -9,16 +9,16 @@ module Sanford
 
   class Worker
 
-    ProcessedService = Struct.new(*[
+    ProcessedService = Struct.new(
       :request, :handler_class, :response, :exception, :time_taken
-    ])
+    )
 
     attr_reader :logger
 
     def initialize(host_data, connection)
-      @host_data, @connection = host_data, connection
-
-      @logger = Sanford::Logger.new(@host_data.logger, @host_data.verbose)
+      @host_data  = host_data
+      @connection = connection
+      @logger = Sanford::Logger.new(@host_data.logger, @host_data.verbose_logging)
     end
 
     def run

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -1,18 +1,20 @@
 require 'assert'
 require 'sanford/error_handler'
 
+require 'sanford/server'
+
 class Sanford::ErrorHandler
 
   class UnitTests < Assert::Context
     desc "Sanford::ErrorHandler"
     setup do
       @exception = RuntimeError.new('test')
-      @host_data = Sanford::HostData.new(EmptyHost, { :ip => "localhost", :port => 8000 })
-      @error_handler = Sanford::ErrorHandler.new(@exception, @host_data)
+      @config_data = Sanford::Server::ConfigData.new
+      @error_handler = Sanford::ErrorHandler.new(@exception, @config_data)
     end
     subject{ @error_handler }
 
-    should have_imeths :exception, :host_data, :request, :run
+    should have_imeths :exception, :config_data, :request, :run
 
     should "return a Sanford::Protocol::Response with `run`" do
       assert_instance_of Sanford::Protocol::Response, subject.run
@@ -31,18 +33,13 @@ class Sanford::ErrorHandler
 
   class ResponseFromProcTests < UnitTests
     desc "generating a respone from an error proc"
-    setup do
-      @host_defaults = { :ip => "localhost", :port => 8000 }
-    end
 
     should "use the return-value of the error proc if it is a protocol response" do
       error_proc = proc do |exception, host_data, request|
         Sanford::Protocol::Response.new([ 567, 'custom message'], 'custom data')
       end
-      host_data = Sanford::HostData.new(EmptyHost, @host_defaults.merge({
-        :error_procs => [ error_proc ]
-      }))
-      response = Sanford::ErrorHandler.new(@exception, host_data).run
+      config_data = Sanford::Server::ConfigData.new(:error_procs => [ error_proc ])
+      response = Sanford::ErrorHandler.new(@exception, config_data).run
 
       assert_equal 567, response.code
       assert_equal 'custom message', response.status.message
@@ -50,10 +47,8 @@ class Sanford::ErrorHandler
     end
 
     should "use an integer returned by the error proc to generate a protocol response" do
-      host_data = Sanford::HostData.new(EmptyHost, @host_defaults.merge({
-        :error_procs => [ proc{ 345 } ]
-      }))
-      response = Sanford::ErrorHandler.new(@exception, host_data).run
+      config_data = Sanford::Server::ConfigData.new(:error_procs => [ proc{ 345 } ])
+      response = Sanford::ErrorHandler.new(@exception, config_data).run
 
       assert_equal 345, response.code
       assert_nil response.status.message
@@ -61,10 +56,10 @@ class Sanford::ErrorHandler
     end
 
     should "use a symbol returned by the error proc to generate a protocol response" do
-      host_data = Sanford::HostData.new(EmptyHost, @host_defaults.merge({
+      config_data = Sanford::Server::ConfigData.new({
         :error_procs => [ proc{ :not_found } ]
-      }))
-      response = Sanford::ErrorHandler.new(@exception, host_data).run
+      })
+      response = Sanford::ErrorHandler.new(@exception, config_data).run
 
       assert_equal 404, response.code
       assert_nil response.status.message
@@ -72,10 +67,8 @@ class Sanford::ErrorHandler
     end
 
     should "use the default behavior if the error proc doesn't return a valid response result" do
-      host_data = Sanford::HostData.new(EmptyHost, @host_defaults.merge({
-        :error_procs => [ proc{ true } ]
-      }))
-      response = Sanford::ErrorHandler.new(@exception, host_data).run
+      config_data = Sanford::Server::ConfigData.new(:error_procs => [ proc{ true } ])
+      response = Sanford::ErrorHandler.new(@exception, config_data).run
 
       assert_equal 500, response.code
       assert_equal 'An unexpected error occurred.', response.status.message
@@ -83,10 +76,10 @@ class Sanford::ErrorHandler
 
     should "use the default behavior for an exception raised by the error proc " \
            "and ignore the original exception" do
-      host_data = Sanford::HostData.new(EmptyHost, @host_defaults.merge({
+      config_data = Sanford::Server::ConfigData.new({
         :error_procs => [ proc{ raise Sanford::NotFoundError } ]
-      }))
-      response = Sanford::ErrorHandler.new(@exception, host_data).run
+      })
+      response = Sanford::ErrorHandler.new(@exception, config_data).run
 
       assert_equal 404, response.code
       assert_nil response.status.message
@@ -100,7 +93,7 @@ class Sanford::ErrorHandler
 
     should "build a 400 response with a protocol BadMessageError" do
       exception = generate_exception(Sanford::Protocol::BadMessageError, 'bad message')
-      response = Sanford::ErrorHandler.new(exception, @host_data).run
+      response = Sanford::ErrorHandler.new(exception, @config_data).run
 
       assert_equal 400, response.code
       assert_equal 'bad message', response.status.message
@@ -108,7 +101,7 @@ class Sanford::ErrorHandler
 
     should "build a 400 response with a protocol BadRequestError" do
       exception = generate_exception(Sanford::Protocol::BadRequestError, 'bad request')
-      response = Sanford::ErrorHandler.new(exception, @host_data).run
+      response = Sanford::ErrorHandler.new(exception, @config_data).run
 
       assert_equal 400, response.code
       assert_equal 'bad request', response.status.message
@@ -116,14 +109,14 @@ class Sanford::ErrorHandler
 
     should "build a 404 response with a NotFoundError" do
       exception = generate_exception(Sanford::NotFoundError, 'not found')
-      response = Sanford::ErrorHandler.new(exception, @host_data).run
+      response = Sanford::ErrorHandler.new(exception, @config_data).run
 
       assert_equal 404, response.code
       assert_nil response.status.message
     end
 
     should "build a 500 response with all other exceptions" do
-      response = Sanford::ErrorHandler.new(RuntimeError.new('test'), @host_data).run
+      response = Sanford::ErrorHandler.new(RuntimeError.new('test'), @config_data).run
 
       assert_equal 500, response.code
       assert_equal 'An unexpected error occurred.', response.status.message
@@ -135,13 +128,14 @@ class Sanford::ErrorHandler
     desc "with multiple error procs"
     setup do
       @first_called, @second_called, @third_called = nil, nil, nil
-      @host_data = Sanford::HostData.new(EmptyHost, @host_defaults.merge({
+      @config_data = Sanford::Server::ConfigData.new({
         :error_procs => [ first_proc, second_proc, third_proc ]
-      }))
+      })
     end
 
     should "call every error proc" do
-      @error_handler = Sanford::ErrorHandler.new(RuntimeError.new('test'), @host_data)
+      exception = RuntimeError.new('test')
+      @error_handler = Sanford::ErrorHandler.new(exception, @config_data)
       @error_handler.run
 
       assert_equal true, @first_called
@@ -151,14 +145,15 @@ class Sanford::ErrorHandler
 
     should "should return the response of the last configured error proc " \
            "that returned a valid response" do
-      @error_handler = Sanford::ErrorHandler.new(RuntimeError.new('test'), @host_data)
+      exception = RuntimeError.new('test')
+      @error_handler = Sanford::ErrorHandler.new(exception, @config_data)
       response = @error_handler.run
 
       # use the second proc's generated response
       assert_equal 987, response.code
 
       exception = generate_exception(Sanford::NotFoundError, 'not found')
-      @error_handler = Sanford::ErrorHandler.new(exception, @host_data)
+      @error_handler = Sanford::ErrorHandler.new(exception, @config_data)
       response = @error_handler.run
 
       # use the third proc's generated response
@@ -170,14 +165,14 @@ class Sanford::ErrorHandler
     end
 
     def second_proc
-      proc do |exception, host_data, request|
+      proc do |exception, config_data, request|
         @second_called = true
         987
       end
     end
 
     def third_proc
-      proc do |exception, host_data, request|
+      proc do |exception, config_data, request|
         @third_called = true
         876 if exception.kind_of?(Sanford::NotFoundError)
       end

--- a/test/unit/host_data_tests.rb
+++ b/test/unit/host_data_tests.rb
@@ -14,7 +14,8 @@ class Sanford::HostData
     end
     subject{ @host_data }
 
-    should have_readers :name, :logger, :verbose, :keep_alive, :error_procs
+    should have_readers :name, :logger, :verbose_logging
+    should have_readers :receives_keep_alive, :error_procs
     should have_imeths :handler_class_for, :run
 
     should "call the init procs" do
@@ -24,21 +25,21 @@ class Sanford::HostData
     should "default its attrs from the host configuration" do
       assert_equal TestHost.configuration.name,                subject.name
       assert_equal TestHost.configuration.logger.class,        subject.logger.class
-      assert_equal TestHost.configuration.verbose_logging,     subject.verbose
-      assert_equal TestHost.configuration.receives_keep_alive, subject.keep_alive
+      assert_equal TestHost.configuration.verbose_logging,     subject.verbose_logging
+      assert_equal TestHost.configuration.receives_keep_alive, subject.receives_keep_alive
       assert_equal TestHost.configuration.error_procs,         subject.error_procs
     end
 
     should "allow overriding host configuration attrs" do
       host_data = Sanford::HostData.new(TestHost, :verbose_logging => false)
 
-      assert_false host_data.verbose
-      assert_equal TestHost.receives_keep_alive, host_data.keep_alive
+      assert_false host_data.verbose_logging
+      assert_equal TestHost.receives_keep_alive, host_data.receives_keep_alive
     end
 
     should "ignore nil values passed as overrides" do
       host_data = Sanford::HostData.new(TestHost, :verbose_logging => nil)
-      assert_not_nil host_data.verbose
+      assert_not_nil host_data.verbose_logging
     end
 
     should "constantize a host's handlers" do


### PR DESCRIPTION
This adds `ConfigData` to the `Server`, which replaces part of the
role that `HostData` currently handles. `HostData` is the
"compiled" data from a `Host`. Similarly, `ConfigData` is the
"compiled" data from the server's `Configuration`. This is done
for speed because `NsOptions` is relatively (when 1-5ms matters)
slow in reading options.

The `ConfigData` is built when the `Server` is initialized and is
seeded by the `Configuration` data. It also handles looking up
routes given a name. The `Server` will use this to find the service
handler it needs to run for a request.

`ConfigData` will also be used by the `ErrorHandler` when an
error occurs. To handle `Sanford` currently using the `HostData`
but needing the `ErrorHandler` to also work with `ConfigData`, I
made their interfaces mostly compatible. This allows updating
the `ErrorHandler` to use `ConfigData` but not breaking the build
which uses the `HostData`. In this case, I didn't want to create
two error handlers, one that worked with `ConfigData` and one
that worked with `HostData`.

All of this is setup for switching out the old server for the new
one.

@kellyredding - Ready for review.
