### PR TITLE
Create `WorkerOld`, copy of `Worker`

### DIFF
--- a/lib/sanford/server_old.rb
+++ b/lib/sanford/server_old.rb
@@ -3,7 +3,7 @@ require 'ostruct'
 require 'sanford-protocol'
 
 require 'sanford/host_data'
-require 'sanford/worker'
+require 'sanford/worker_old'
 
 module Sanford
 
@@ -69,7 +69,7 @@ module Sanford
     def serve(socket)
       connection = Connection.new(socket)
       if !self.keep_alive_connection?(connection)
-        Sanford::Worker.new(@sanford_host_data, connection).run
+        Sanford::WorkerOld.new(@sanford_host_data, connection).run
       end
     end
 

--- a/lib/sanford/worker_old.rb
+++ b/lib/sanford/worker_old.rb
@@ -1,0 +1,142 @@
+require 'benchmark'
+require 'sanford-protocol'
+
+require 'sanford/error_handler'
+require 'sanford/logger'
+require 'sanford/runner'
+
+module Sanford
+
+  class WorkerOld
+
+    ProcessedService = Struct.new(
+      :request, :handler_class, :response, :exception, :time_taken
+    )
+
+    attr_reader :logger
+
+    def initialize(host_data, connection)
+      @host_data  = host_data
+      @connection = connection
+      @logger = Sanford::Logger.new(@host_data.logger, @host_data.verbose_logging)
+    end
+
+    def run
+      processed_service = nil
+      self.log_received
+      benchmark = Benchmark.measure do
+        processed_service = self.run!
+      end
+      processed_service.time_taken = RoundedTime.new(benchmark.real)
+      self.log_complete(processed_service)
+      self.raise_if_debugging!(processed_service.exception)
+      processed_service
+    end
+
+    protected
+
+    def run!
+      service = ProcessedService.new
+      begin
+        request = Sanford::Protocol::Request.parse(@connection.read_data)
+        self.log_request(request)
+        service.request = request
+
+        handler_class = @host_data.handler_class_for(request.name)
+        self.log_handler_class(handler_class)
+        service.handler_class = handler_class
+
+        response = @host_data.run(handler_class, request)
+        service.response = response
+      rescue Exception => exception
+        self.handle_exception(service, exception, @host_data)
+      ensure
+        self.write_response(service)
+      end
+      service
+    end
+
+    def write_response(service)
+      begin
+        @connection.write_data service.response.to_hash
+      rescue Exception => exception
+        service = self.handle_exception(service, exception)
+        @connection.write_data service.response.to_hash
+      end
+      @connection.close_write
+      service
+    end
+
+    def handle_exception(service, exception, host_data = nil)
+      error_handler = Sanford::ErrorHandler.new(exception, host_data, service.request)
+      service.response  = error_handler.run
+      service.exception = error_handler.exception
+      self.log_exception(service.exception)
+      service
+    end
+
+    def raise_if_debugging!(exception)
+      raise exception if exception && ENV['SANFORD_DEBUG']
+    end
+
+    def log_received
+      log_verbose "===== Received request ====="
+    end
+
+    def log_request(request)
+      log_verbose "  Service: #{request.name.inspect}"
+      log_verbose "  Params:  #{request.params.inspect}"
+    end
+
+    def log_handler_class(handler_class)
+      log_verbose "  Handler: #{handler_class}"
+    end
+
+    def log_complete(processed_service)
+      log_verbose "===== Completed in #{processed_service.time_taken}ms " \
+                  "#{processed_service.response.status} ====="
+      summary_line_args = {
+        'time'    => processed_service.time_taken,
+        'handler' => processed_service.handler_class
+      }
+      if processed_service.response
+        summary_line_args['status'] = processed_service.response.code
+      end
+      if (request = processed_service.request)
+        summary_line_args['service'] = request.name
+        summary_line_args['params']  = request.params
+      end
+      log_summary SummaryLine.new(summary_line_args)
+    end
+
+    def log_exception(exception)
+      log_verbose("#{exception.class}: #{exception.message}", :error)
+      log_verbose(exception.backtrace.join("\n"), :error)
+    end
+
+    def log_verbose(message, level = :info)
+      self.logger.verbose.send(level, "[Sanford] #{message}")
+    end
+
+    def log_summary(message, level = :info)
+      self.logger.summary.send(level, "[Sanford] #{message}")
+    end
+
+    module RoundedTime
+      ROUND_PRECISION = 2
+      ROUND_MODIFIER = 10 ** ROUND_PRECISION
+      def self.new(time_in_seconds)
+        (time_in_seconds * 1000 * ROUND_MODIFIER).to_i / ROUND_MODIFIER.to_f
+      end
+    end
+
+    module SummaryLine
+      def self.new(line_attrs)
+        attr_keys = %w{time status handler version service params}
+        attr_keys.map{ |k| "#{k}=#{line_attrs[k].inspect}" }.join(' ')
+      end
+    end
+
+  end
+
+end

--- a/test/system/request_handling_tests.rb
+++ b/test/system/request_handling_tests.rb
@@ -30,7 +30,7 @@ class RequestHandlingTests < Assert::Context
     desc "running a request for the echo server"
     setup do
       @connection = FakeConnection.with_request('echo', { :message => 'test' })
-      @worker = Sanford::Worker.new(@host_data, @connection)
+      @worker = Sanford::WorkerOld.new(@host_data, @connection)
     end
 
     should "return a successful response and echo the params sent to it" do
@@ -56,7 +56,7 @@ class RequestHandlingTests < Assert::Context
       request_hash = Sanford::Protocol::Request.new('what', {}).to_hash
       request_hash.delete('name')
       @connection = FakeConnection.new(request_hash)
-      @worker = Sanford::Worker.new(@host_data, @connection)
+      @worker = Sanford::WorkerOld.new(@host_data, @connection)
     end
 
     should "return a bad request response" do
@@ -77,7 +77,7 @@ class RequestHandlingTests < Assert::Context
     desc "running a request with no matching service name"
     setup do
       @connection = FakeConnection.with_request('what', {})
-      @worker = Sanford::Worker.new(@host_data, @connection)
+      @worker = Sanford::WorkerOld.new(@host_data, @connection)
     end
 
     should "return a bad request response" do
@@ -97,7 +97,7 @@ class RequestHandlingTests < Assert::Context
     desc "running a request that errors on the server"
     setup do
       @connection = FakeConnection.with_request('bad', {})
-      @worker = Sanford::Worker.new(@host_data, @connection)
+      @worker = Sanford::WorkerOld.new(@host_data, @connection)
     end
 
     should "return a bad request response" do
@@ -117,7 +117,7 @@ class RequestHandlingTests < Assert::Context
     desc "running a request that halts"
     setup do
       @connection = FakeConnection.with_request('halt_it', {})
-      @worker = Sanford::Worker.new(@host_data, @connection)
+      @worker = Sanford::WorkerOld.new(@host_data, @connection)
     end
 
     should "return the response that was halted" do
@@ -135,7 +135,7 @@ class RequestHandlingTests < Assert::Context
     desc "running a request that halts in a callback"
     setup do
       @connection = FakeConnection.with_request('authorized', {})
-      @worker = Sanford::Worker.new(@host_data, @connection)
+      @worker = Sanford::WorkerOld.new(@host_data, @connection)
     end
 
     should "return the response that was halted" do
@@ -153,7 +153,7 @@ class RequestHandlingTests < Assert::Context
     desc "running a request that triggers our custom error handler"
     setup do
       @connection = FakeConnection.with_request('custom_error', {})
-      @worker = Sanford::Worker.new(@host_data, @connection)
+      @worker = Sanford::WorkerOld.new(@host_data, @connection)
     end
 
     should "return the response that was halted" do
@@ -171,7 +171,7 @@ class RequestHandlingTests < Assert::Context
     desc "running a request that builds an object that can't be encoded"
     setup do
       @connection = FakeConnection.with_request('echo', { :message => 'cant encode' }, true)
-      @worker = Sanford::Worker.new(@host_data, @connection)
+      @worker = Sanford::WorkerOld.new(@host_data, @connection)
     end
 
     should "return the response that was halted" do

--- a/test/unit/worker_old_tests.rb
+++ b/test/unit/worker_old_tests.rb
@@ -1,17 +1,17 @@
 require 'assert'
-require 'sanford/worker'
+require 'sanford/worker_old'
 
 require 'sanford/host_data'
 require 'test/support/fake_connection'
 
-class Sanford::Worker
+class Sanford::WorkerOld
 
   class UnitTests < Assert::Context
-    desc "Sanford::Worker"
+    desc "Sanford::WorkerOld"
     setup do
       @host_data = Sanford::HostData.new(TestHost)
       @connection = FakeConnection.with_request('service', {})
-      @worker = Sanford::Worker.new(@host_data, @connection)
+      @worker = Sanford::WorkerOld.new(@host_data, @connection)
     end
     subject{ @worker }
 
@@ -19,6 +19,6 @@ class Sanford::Worker
 
   end
 
-  # `Worker`'s logic is tested in the system test: `request_handling_test.rb`
+  # `WorkerOld`'s logic is tested in the system test: `request_handling_test.rb`
 
 end


### PR DESCRIPTION
This is setup for changing `Worker` to work with the new `Server`.
This takes the current worker logic and moves it to `WorkerOld`
and updates everything using `Worker` to use `WorkerOld` instead.

I did this to free-up the `Worker` name but I also wanted to
preserve the diff from the old worker logic to the new worker
logic which will come in a separate commit. That's why I left the
old worker logic in `sanford/worker.rb`.

@kellyredding - Ready for review. I'm not changing any functionality here, just prepping for the changes to `Worker` to work with the new `Server` but keep the old stuff intact. There aren't many changes to `Worker`, so I wanted to highlight them in the diff.
