### PR TITLE
Update `Worker` to work with `Server::ConfigData`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,7 @@ gem 'rake'
 gem 'pry', "~> 0.9.0"
 
 gem 'bson_ext'
+
+gem 'sanford-protocol',
+  :git => "git@github.com:redding/sanford-protocol.git",
+  :branch => "master"

--- a/test/support/fake_connection.rb
+++ b/test/support/fake_connection.rb
@@ -1,6 +1,8 @@
 class FakeConnection
 
-  attr_reader :read_data, :response, :write_stream_closed
+  attr_reader :read_data, :response
+  attr_reader :write_stream_closed
+  attr_accessor :raise_on_write, :write_exception
 
   def self.with_request(name, params = {}, raise_on_write = false)
     request = Sanford::Protocol::Request.new(name, params)
@@ -15,6 +17,7 @@ class FakeConnection
     else
       @read_data, @raise_on_write = args
     end
+    @write_exception = RuntimeError.new('test fail')
   end
 
   def read_data
@@ -24,13 +27,17 @@ class FakeConnection
   def write_data(data)
     if @raise_on_write
       @raise_on_write = false
-      raise 'test fail'
+      raise @write_exception
     end
     @response = Sanford::Protocol::Response.parse(data)
   end
 
   def close_write
     @write_stream_closed = true
+  end
+
+  def request
+    @request ||= Sanford::Protocol::Request.parse(self.read_data)
   end
 
 end

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -1,0 +1,254 @@
+require 'assert'
+require 'sanford/worker'
+
+require 'sanford/route'
+require 'sanford/server'
+require 'test/support/fake_connection'
+
+class Sanford::Worker
+
+  class UnitTests < Assert::Context
+    desc "Sanford::Worker"
+    setup do
+      @route = Sanford::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
+      @config_data = Sanford::Server::ConfigData.new({
+        :logger => Sanford::NullLogger.new,
+        :verbose_logging => Factory.boolean,
+        :routes => [ @route ]
+      })
+      @connection = FakeConnection.with_request(@route.name, {})
+      @request = @connection.request
+      @response = Sanford::Protocol::Response.new(Factory.integer, Factory.string)
+      @exception = RuntimeError.new(Factory.string)
+
+      @worker_class = Sanford::Worker
+    end
+    subject{ @worker_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @worker = @worker_class.new(@config_data, @connection)
+    end
+    subject{ @worker }
+
+    should have_readers :config_data, :connection
+    should have_readers :logger
+    should have_imeths :run
+
+    should "know its config data and connection" do
+      assert_equal @config_data, subject.config_data
+      assert_equal @connection, subject.connection
+    end
+
+    should "know its logger" do
+      assert_instance_of Sanford::Logger, subject.logger
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @route_called_with = nil
+      Assert.stub(@route, :run) do |*args|
+        @route_called_with = args
+        @response
+      end
+
+      @processed_service = @worker.run
+    end
+    subject{ @processed_service }
+
+    should "return a processed service" do
+      assert_instance_of ProcessedService, subject
+      assert_equal @request, subject.request
+      assert_equal @route.handler_class, subject.handler_class
+      assert_equal @response, subject.response
+      assert_nil subject.exception
+      assert_not_nil subject.time_taken
+    end
+
+    should "run the route" do
+      assert_not_nil @route_called_with
+      assert_includes @request, @route_called_with
+      assert_includes @config_data.logger, @route_called_with
+    end
+
+    should "have written the response to the connection" do
+      assert_equal @response, @connection.response
+      assert_true @connection.write_stream_closed
+    end
+
+  end
+
+  class RunWithExceptionTests < InitTests
+    desc "and run with a route that throws an exception"
+    setup do
+      Assert.stub(@route, :run){ raise @exception }
+
+      error_handler = Sanford::ErrorHandler.new(
+        @exception,
+        @config_data,
+        @request
+      )
+      @expected_response = error_handler.run
+      @expected_exception = error_handler.exception
+
+      @processed_service = @worker.run
+    end
+    subject{ @processed_service }
+
+    should "return a processed service with an exception" do
+      assert_instance_of ProcessedService, subject
+      assert_equal @expected_response,  subject.response
+      assert_equal @expected_exception, subject.exception
+    end
+
+    should "have written the error response to the connection" do
+      assert_equal @expected_response, @connection.response
+      assert_true @connection.write_stream_closed
+    end
+
+  end
+
+  class RunWithExceptionWhileWritingTests < InitTests
+    desc "and run with an exception thrown while writing the response"
+    setup do
+      Assert.stub(@route, :run){ @response }
+
+      @connection.raise_on_write = true
+
+      error_handler = Sanford::ErrorHandler.new(
+        @connection.write_exception,
+        @config_data,
+        @request
+      )
+      @expected_response = error_handler.run
+      @expected_exception = error_handler.exception
+
+      @processed_service = @worker.run
+    end
+    subject{ @processed_service }
+
+    should "return a processed service with an exception" do
+      assert_instance_of ProcessedService, subject
+      assert_equal @expected_response,  subject.response
+      assert_equal @expected_exception, subject.exception
+    end
+
+    should "have written the error response to the connection" do
+      assert_equal @expected_response, @connection.response
+      assert_true @connection.write_stream_closed
+    end
+
+  end
+
+  class RunWithExceptionWhileDebuggingTests < InitTests
+    desc "and run with a route that throws an exception in debug mode"
+    setup do
+      ENV['SANFORD_DEBUG'] = '1'
+      Assert.stub(@route, :run){ raise @exception }
+    end
+    teardown do
+      ENV.delete('SANFORD_DEBUG')
+    end
+
+    should "raise the exception" do
+      assert_raises(@exception.class){ @worker.run }
+    end
+
+  end
+
+  class RunWithVerboseLoggingTests < UnitTests
+    desc "run with verbose logging"
+    setup do
+      @spy_logger = SpyLogger.new
+      @config_data = Sanford::Server::ConfigData.new({
+        :logger => @spy_logger,
+        :verbose_logging => true,
+        :routes => [ @route ]
+      })
+      Assert.stub(@route, :run){ raise @exception }
+
+      @worker = @worker_class.new(@config_data, @connection)
+      @processed_service = @worker.run
+    end
+    subject{ @spy_logger }
+
+    should "have logged the service" do
+      time_taken = @processed_service.time_taken
+      status = @processed_service.response.status.to_s
+      expected = "[Sanford] ===== Received request =====" \
+                 "[Sanford]   Service: #{@request.name.inspect}" \
+                 "[Sanford]   Params:  #{@request.params.inspect}" \
+                 "[Sanford]   Handler: #{@route.handler_class}" \
+                 "[Sanford] ===== Completed in #{time_taken}ms #{status} ====="
+      assert_equal expected, subject.info_logged.join
+    end
+
+    should "log an exception when one is thrown" do
+      err = @processed_service.exception
+      backtrace = err.backtrace.join("\n")
+      expected = "[Sanford] #{err.class}: #{err.message}\n#{backtrace}"
+      assert_equal expected, subject.error_logged.join
+    end
+
+  end
+
+  class RunWithSummaryLoggingTests < UnitTests
+    desc "run with summary logging"
+    setup do
+      @spy_logger = SpyLogger.new
+      @config_data = Sanford::Server::ConfigData.new({
+        :logger => @spy_logger,
+        :verbose_logging => false,
+        :routes => [ @route ]
+      })
+      Assert.stub(@route, :run){ raise @exception }
+
+      @worker = @worker_class.new(@config_data, @connection)
+      @processed_service = @worker.run
+    end
+    subject{ @spy_logger }
+
+    should "have logged the service" do
+      time_taken = @processed_service.time_taken
+      status = @processed_service.response.status.to_i
+      expected = "[Sanford] " \
+                 "time=#{time_taken} " \
+                 "status=#{status} " \
+                 "handler=#{@route.handler_class} " \
+                 "service=#{@request.name.inspect} " \
+                 "params=#{@request.params.inspect}"
+      assert_equal expected, subject.info_logged.join
+    end
+
+    should "not have logged the exception" do
+      assert_empty @spy_logger.error_logged
+    end
+
+  end
+
+  TestHandler = Class.new
+
+  class SpyLogger
+    attr_reader :info_logged, :error_logged
+
+    def initialize
+      @info_logged = []
+      @error_logged = []
+    end
+
+    def info(message)
+      @info_logged << message
+    end
+
+    def error(message)
+      @error_logged << message
+    end
+  end
+
+end


### PR DESCRIPTION
This updates the `Worker` to work with the `Server::ConfigData`.
Overall, the worker works as it previously did. It takes a
connection and config data, and when run, reads the request,
runs a service handler and writes a response. The biggest
difference is that it now looks up a route via the config data and
then runs the route, passing it the request and the config data
logger. Previously, it would get the handler class from the host
data and then have the host data run the handler class, passing
the request. This is part of switching to the new server logic.
The new `Server` will run this `Worker` similar to how the old
server logic runs the old worker now.

This also adds proper unit tests for the worker tests which
basically weren't done for the old worker logic.

Finally, this removes `version` from the summary logging. This
should have been done when we removed version as a part of a
request, but was missed.

@kellyredding - Ready for review.
