### PR TITLE
Build DatTCP server when initializing a Sanford server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,6 +7,9 @@ gem 'pry', "~> 0.9.0"
 
 gem 'bson_ext'
 
+gem 'dat-tcp',
+  :git => "git@github.com:redding/dat-tcp.git",
+  :branch => "master"
 gem 'sanford-protocol',
   :git => "git@github.com:redding/sanford-protocol.git",
   :branch => "master"

--- a/test/support/fake_connection.rb
+++ b/test/support/fake_connection.rb
@@ -1,7 +1,7 @@
 class FakeConnection
 
-  attr_reader :read_data, :response
-  attr_reader :write_stream_closed
+  attr_reader :read_data
+  attr_reader :response, :write_stream_closed
   attr_accessor :raise_on_write, :write_exception
 
   def self.with_request(name, params = {}, raise_on_write = false)
@@ -24,12 +24,20 @@ class FakeConnection
     @read_data.kind_of?(Proc) ? @read_data.call : @read_data
   end
 
+  def read_data=(value)
+    @read_data = value || ""
+  end
+
   def write_data(data)
     if @raise_on_write
       @raise_on_write = false
       raise @write_exception
     end
     @response = Sanford::Protocol::Response.parse(data)
+  end
+
+  def peek_data
+    self.read_data[1] || ""
   end
 
   def close_write

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -1,8 +1,11 @@
 require 'assert'
 require 'sanford/server'
 
+require 'dat-tcp/server_spy'
 require 'ns-options/assert_macros'
 require 'sanford/route'
+require 'sanford-protocol/fake_connection'
+require 'test/support/fake_connection'
 
 module Sanford::Server
 
@@ -94,6 +97,15 @@ module Sanford::Server
       assert_equal new_router, subject.router
     end
 
+    should "allow configuring the router by passing a block to `router`" do
+      new_router = Factory.string
+
+      block_scope = nil
+      subject.router(new_router){ block_scope = self }
+      assert_equal new_router, subject.router
+      assert_equal new_router, block_scope
+    end
+
     should "allow setting the configuration template source" do
       new_path = Factory.string
       yielded = nil
@@ -104,34 +116,239 @@ module Sanford::Server
 
   end
 
-  class WithConfigurationSetTests < UnitTests
+  class InitTests < UnitTests
+    desc "when init"
     setup do
       @server_class.name Factory.string
       @server_class.ip Factory.string
       @server_class.port Factory.integer
-      @server_class.pid_file Factory.string
-    end
+      @server_class.error{ Factory.string }
+      @server_class.router do
+        service Factory.string, TestHandler.to_s
+      end
 
-  end
+      @dat_tcp_server_spy = DatTCP::ServerSpy.new
+      Assert.stub(DatTCP::Server, :new) do |&block|
+        @dat_tcp_server_spy.serve_proc = block
+        @dat_tcp_server_spy
+      end
 
-  class InitTests < WithConfigurationSetTests
-    desc "when init"
-    setup do
       @server = @server_class.new
     end
     subject{ @server }
 
-    attr_reader :config_data
+    should have_readers :config_data, :dat_tcp_server
+    should have_imeths :ip, :port, :file_descriptor, :client_file_descriptors
+    should have_imeths :listen, :start, :pause, :stop, :halt
 
     should "have validated its configuration" do
       assert_true subject.class.configuration.valid?
     end
 
     should "know its config data" do
-      assert_instance_of ConfigData, subject.config_data
       configuration = subject.class.configuration
-      assert_equal configuration.name, subject.config_data.name
+      cd = subject.config_data
+
+      assert_instance_of ConfigData, cd
+      assert_equal configuration.name, cd.name
+      assert_equal configuration.ip, cd.ip
+      assert_equal configuration.port, cd.port
+      assert_equal configuration.verbose_logging, cd.verbose_logging
+      assert_equal configuration.receives_keep_alive, cd.receives_keep_alive
+      assert_equal configuration.error_procs, cd.error_procs
+      assert_equal configuration.routes, cd.routes.values
+      assert_instance_of configuration.logger.class, cd.logger
     end
+
+    should "know its dat tcp server" do
+      assert_equal @dat_tcp_server_spy, subject.dat_tcp_server
+      assert_not_nil @dat_tcp_server_spy.serve_proc
+    end
+
+    should "call listen on its dat tcp server using `listen`" do
+      subject.listen
+      assert_true @dat_tcp_server_spy.listen_called
+    end
+
+    should "use its configured ip and port by default when listening" do
+      subject.listen
+      assert_equal subject.config_data.ip, @dat_tcp_server_spy.ip
+      assert_equal subject.config_data.port, @dat_tcp_server_spy.port
+    end
+
+    should "pass any args to its dat tcp server using `listen`" do
+      ip, port = Factory.string, Factory.integer
+      subject.listen(ip, port)
+      assert_equal ip, @dat_tcp_server_spy.ip
+      assert_equal port, @dat_tcp_server_spy.port
+
+      file_descriptor = Factory.integer
+      subject.listen(file_descriptor)
+      assert_equal file_descriptor, @dat_tcp_server_spy.file_descriptor
+    end
+
+    should "know its ip, port and file descriptor" do
+      assert_equal @dat_tcp_server_spy.ip, subject.ip
+      assert_equal @dat_tcp_server_spy.port, subject.port
+      subject.listen
+      assert_equal @dat_tcp_server_spy.ip, subject.ip
+      assert_equal @dat_tcp_server_spy.port, subject.port
+
+      assert_equal @dat_tcp_server_spy.file_descriptor, subject.file_descriptor
+      subject.listen(Factory.integer)
+      assert_equal @dat_tcp_server_spy.file_descriptor, subject.file_descriptor
+    end
+
+    should "call start on its dat tcp server using `start`" do
+      client_fds = [ Factory.integer ]
+      subject.start(client_fds)
+      assert_true @dat_tcp_server_spy.start_called
+      assert_equal client_fds, @dat_tcp_server_spy.client_file_descriptors
+    end
+
+    should "know its client file descriptors" do
+      expected = @dat_tcp_server_spy.client_file_descriptors
+      assert_equal expected, subject.client_file_descriptors
+      subject.start([ Factory.integer ])
+      expected = @dat_tcp_server_spy.client_file_descriptors
+      assert_equal expected, subject.client_file_descriptors
+    end
+
+    should "call pause on its dat tcp server using `pause`" do
+      wait = Factory.boolean
+      subject.pause(wait)
+      assert_true @dat_tcp_server_spy.pause_called
+      assert_equal wait, @dat_tcp_server_spy.waiting_for_pause
+    end
+
+    should "call stop on its dat tcp server using `stop`" do
+      wait = Factory.boolean
+      subject.stop(wait)
+      assert_true @dat_tcp_server_spy.stop_called
+      assert_equal wait, @dat_tcp_server_spy.waiting_for_stop
+    end
+
+    should "call halt on its dat tcp server using `halt`" do
+      wait = Factory.boolean
+      subject.halt(wait)
+      assert_true @dat_tcp_server_spy.halt_called
+      assert_equal wait, @dat_tcp_server_spy.waiting_for_halt
+    end
+
+  end
+
+  class ConfigureTCPServerTests < InitTests
+    desc "configuring its tcp server"
+    setup do
+      @tcp_server = TCPServerSpy.new
+      Assert.stub(@dat_tcp_server_spy, :listen) do |*args, &block|
+        @configure_tcp_server_proc = block
+      end
+      @server.listen
+      @configure_tcp_server_proc.call(@tcp_server)
+    end
+    subject{ @tcp_server }
+
+    should "set the TCP_NODELAY option" do
+      expected = [ ::Socket::IPPROTO_TCP, ::Socket::TCP_NODELAY, true ]
+      assert_includes expected, @tcp_server.set_socket_option_calls
+    end
+
+  end
+
+  class ServeTests < InitTests
+    desc "serve"
+    setup do
+      @socket = Factory.binary
+
+      @connection = FakeConnection.new
+      Assert.stub(Connection, :new).with(@socket){ @connection }
+
+      @worker_spy = WorkerSpy.new
+      Assert.stub(Sanford::Worker, :new).tap do |s|
+        s.with(@server.config_data, @connection){ @worker_spy }
+      end
+
+      @serve_proc = @dat_tcp_server_spy.serve_proc
+    end
+    subject{ @serve_proc }
+
+    should "run a worker when called with a socket" do
+      Assert.stub(@server.config_data, :receives_keep_alive){ false }
+      @connection.read_data = Factory.boolean
+      assert_false @worker_spy.run_called
+      subject.call(@socket)
+      assert_true @worker_spy.run_called
+    end
+
+    should "not run a keep-alive connection when configured to receive them" do
+      Assert.stub(@server.config_data, :receives_keep_alive){ true }
+      @connection.read_data = nil # nothing to read makes it a keep-alive
+      assert_false @worker_spy.run_called
+      subject.call(@socket)
+      assert_false @worker_spy.run_called
+    end
+
+    should "run a keep-alive connection when configured to receive them" do
+      Assert.stub(@server.config_data, :receives_keep_alive){ false }
+      @connection.read_data = nil # nothing to read makes it a keep-alive
+      assert_false @worker_spy.run_called
+      subject.call(@socket)
+      assert_true @worker_spy.run_called
+    end
+
+  end
+
+  class ConnectionTests < UnitTests
+    desc "Connection"
+    setup do
+      fake_socket = Factory.string
+      @protocol_conn = Sanford::Protocol::FakeConnection.new(Factory.binary)
+      Assert.stub(Sanford::Protocol::Connection, :new).with(fake_socket) do
+        @protocol_conn
+      end
+      @connection = Connection.new(fake_socket)
+    end
+    subject{ @connection }
+
+    should have_imeths :read_data, :write_data, :peek_data
+    should have_imeths :close_write
+
+    should "default its timeout" do
+      assert_equal 1.0, subject.timeout
+    end
+
+    should "allowing reading from the protocol connection" do
+      result = subject.read_data
+      assert_equal @protocol_conn.read_data, result
+      assert_equal @protocol_conn.read_timeout, subject.timeout
+    end
+
+    should "allowing writing to the protocol connection" do
+      data = Factory.binary
+      subject.write_data(data)
+      assert_equal @protocol_conn.write_data, data
+    end
+
+    should "allowing peeking from the protocol connection" do
+      result = subject.peek_data
+      assert_equal @protocol_conn.peek_data, result
+      assert_equal @protocol_conn.peek_timeout, subject.timeout
+    end
+
+    should "allow closing the write stream on the protocol connection" do
+      assert_false @protocol_conn.closed_write
+      subject.close_write
+      assert_true @protocol_conn.closed_write
+    end
+
+  end
+
+  class TCPCorkTests < UnitTests
+    desc "TCPCork"
+    subject{ TCPCork }
+
+    should have_imeths :apply, :remove
 
   end
 
@@ -224,6 +441,7 @@ module Sanford::Server
     should have_readers :template_source
     should have_imeths :set_template_source
     should have_imeths :routes
+    should have_imeths :to_hash
     should have_imeths :valid?, :validate!
 
     should "be an ns-options proxy" do
@@ -275,6 +493,12 @@ module Sanford::Server
       assert_equal subject.router.routes, subject.routes
     end
 
+    should "include its routes and error procs in its hash" do
+      config_hash = subject.to_hash
+      assert_equal subject.error_procs, config_hash[:error_procs]
+      assert_equal subject.routes, config_hash[:routes]
+    end
+
     should "call its init procs when validated" do
       called = false
       subject.init_procs << proc{ called = true }
@@ -307,5 +531,29 @@ module Sanford::Server
   end
 
   TestHandler = Class.new
+
+  class TCPServerSpy
+    attr_reader :set_socket_option_calls
+
+    def initialize
+      @set_socket_option_calls = []
+    end
+
+    def setsockopt(*args)
+      @set_socket_option_calls << args
+    end
+  end
+
+  class WorkerSpy
+    attr_reader :run_called
+
+    def initialize
+      @run_called = false
+    end
+
+    def run
+      @run_called = true
+    end
+  end
 
 end


### PR DESCRIPTION
This updates the new server logic to build a DatTCP server. This
allows the Sanford server to actually listen and serve connections
made to it. This adds the same socket handling behavior as the
old server logic, only it builds and runs a new worker. This also
adds all the same configuration and socket handling from the old
server logic. The TCP server will have the `TCP_NODELAY` option
set on it and in a linux environment, the client socket will
be "corked" as before. This finishes the main work on the
new `Server` logic and it can now replace the old server logic
in the test suite.

This also fixes a few mistakes made in previous commits. The
configuration now adds its routes and error procs to its hash.
Otherwise the config data won't ever get them. I also updated the
`router` DSL method to take a block so services could be added
to the router via the server definition.

@kellyredding - Ready for review.
