### PR TITLE
Add `PIDFile` for managing a Sanford process PID file

### DIFF
--- a/lib/sanford/pid_file.rb
+++ b/lib/sanford/pid_file.rb
@@ -1,0 +1,42 @@
+require 'fileutils'
+
+module Sanford
+
+  class PIDFile
+    attr_reader :path
+
+    def initialize(path)
+      @path = (path || '/dev/null').to_s
+    end
+
+    def pid
+      pid = File.read(@path).strip
+      pid && !pid.empty? ? pid.to_i : raise('no pid in file')
+    rescue StandardError => exception
+      error = InvalidError.new("A PID couldn't be read from #{@path.inspect}")
+      error.set_backtrace(exception.backtrace)
+      raise error
+    end
+
+    def write
+      FileUtils.mkdir_p(File.dirname(@path))
+      File.open(@path, 'w'){ |f| f.puts ::Process.pid }
+    rescue StandardError => exception
+      error = InvalidError.new("Can't write pid to file #{@path.inspect}")
+      error.set_backtrace(exception.backtrace)
+      raise error
+    end
+
+    def remove
+      FileUtils.rm_f(@path)
+    end
+
+    def to_s
+      @path
+    end
+
+    InvalidError = Class.new(RuntimeError)
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -8,17 +8,18 @@ require 'pry' # require pry for debugging (`binding.pry`)
 
 ENV['SANFORD_PROTOCOL_DEBUG'] = 'yes'
 
-require 'sanford'
-ROOT = File.expand_path('../..', __FILE__)
+require 'pathname'
+ROOT_PATH = Pathname.new(File.expand_path('../..', __FILE__))
 
+require 'sanford'
 MyTestEngine = Class.new(Sanford::TemplateEngine) do
   def render(path, service_handler, locals)
     [path.to_s, service_handler.class.to_s, locals]
   end
 end
 Sanford.configure do |config|
-  config.services_file = File.join(ROOT, 'test/support/services')
-  config.set_template_source File.join(ROOT, 'test/support') do |s|
+  config.services_file = ROOT_PATH.join('test/support/services').to_s
+  config.set_template_source ROOT_PATH.join('test/support').to_s do |s|
     s.engine 'test', MyTestEngine
   end
 end

--- a/test/support/test.sanford
+++ b/test/support/test.sanford
@@ -2,7 +2,9 @@ require 'pathname'
 require 'sanford'
 require 'sanford-protocol'
 
-ROOT_PATH = Pathname.new(File.expand_path('../../..', __FILE__))
+if !defined?(ROOT_PATH)
+  ROOT_PATH = Pathname.new(File.expand_path('../../..', __FILE__))
+end
 
 class TestServer
   include Sanford::Server

--- a/test/unit/manager_tests.rb
+++ b/test/unit/manager_tests.rb
@@ -102,7 +102,7 @@ module Sanford::Manager
   class PIDFileTests < ConfigTests
     desc "PIDFile"
     setup do
-      @pid_file_path = File.join(ROOT, "tmp/my.pid")
+      @pid_file_path = ROOT_PATH.join("tmp/my.pid").to_s
       @pid_file = Sanford::Manager::Config::PIDFile.new(@pid_file_path)
     end
     teardown do

--- a/test/unit/pid_file_tests.rb
+++ b/test/unit/pid_file_tests.rb
@@ -1,0 +1,70 @@
+require 'assert'
+require 'sanford/pid_file'
+
+class Sanford::PIDFile
+
+  class UnitTests < Assert::Context
+    desc "Sanford::PIDFile"
+    setup do
+      @path = ROOT_PATH.join('tmp/pid_file_tests.pid').to_s
+      @pid_file = Sanford::PIDFile.new(@path)
+    end
+    teardown do
+      FileUtils.rm_rf(@path)
+    end
+    subject{ @pid_file }
+
+    should have_readers :path
+    should have_imeths :pid, :write, :remove, :to_s
+
+    should "know its path" do
+      assert_equal @path, subject.path
+    end
+
+    should "default its path" do
+      pid_file = Sanford::PIDFile.new(nil)
+      assert_equal '/dev/null', pid_file.path
+    end
+
+    should "know its string format" do
+      assert_equal @path, subject.to_s
+    end
+
+    should "read a PID from its file" do
+      pid = Factory.integer
+      File.open(@path, 'w'){ |f| f.puts pid }
+      assert_equal pid, subject.pid
+    end
+
+    should "raise an invalid error when it can't read from its file" do
+      FileUtils.rm_rf(@path)
+      assert_raises(InvalidError){ subject.pid }
+    end
+
+    should "raise an invalid error when the file doesn't have a PID in it" do
+      File.open(@path, 'w'){ |f| f.puts '' }
+      assert_raises(InvalidError){ subject.pid }
+    end
+
+    should "write the process PID to its file" do
+      assert_false File.exists?(@path)
+      subject.write
+      assert_true File.exists?(@path)
+      assert_equal "#{::Process.pid}\n", File.read(@path)
+    end
+
+    should "raise an invalid error when it can't write its file" do
+      Assert.stub(File, :open){ raise "can't open file" }
+      assert_raises(InvalidError){ subject.write }
+    end
+
+    should "remove its file" do
+      FileUtils.touch(@path)
+      assert_true File.exists?(@path)
+      subject.remove
+      assert_false File.exists?(@path)
+    end
+
+  end
+
+end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -50,7 +50,7 @@ class Sanford::TemplateEngine
   class NullTemplateEngineTests < Assert::Context
     desc "Sanford::NullTemplateEngine"
     setup do
-      @engine = Sanford::NullTemplateEngine.new('source_path' => ROOT)
+      @engine = Sanford::NullTemplateEngine.new('source_path' => ROOT_PATH.to_s)
     end
     subject{ @engine }
 

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -18,7 +18,7 @@ class Sanford::TemplateSource
 
   class InitTests < Assert::Context
     setup do
-      @source_path = File.join(ROOT, 'test/support')
+      @source_path = ROOT_PATH.join('test/support').to_s
       @source = Sanford::TemplateSource.new(@source_path)
     end
     subject{ @source }


### PR DESCRIPTION
This adds a helper class for managing a Sanford process PID file.
When a Sanford process is started, it writes its PID file to a
configured path. This is used to control the Sanford process when
using the CLI. When a stop, halt or restart command is given, the
PID file will be read and a TERM, INT or USR2 signal will be sent
to the process. This logic will be used by both the building and
running a Sanford process set of logic and the sending signals
to a Sanford process set of logic.

@kellyredding - Ready for review.
