### PR TITLE
Add `ProcessSignal` for sending signals to a Sanford process

### DIFF
--- a/lib/sanford/process_signal.rb
+++ b/lib/sanford/process_signal.rb
@@ -1,0 +1,20 @@
+require 'sanford/pid_file'
+
+module Sanford
+
+  class ProcessSignal
+
+    attr_reader :signal, :pid
+
+    def initialize(server, signal)
+      @signal = signal
+      @pid = PIDFile.new(server.pid_file).pid
+    end
+
+    def send
+      ::Process.kill(@signal, @pid)
+    end
+
+  end
+
+end

--- a/test/support/pid_file_spy.rb
+++ b/test/support/pid_file_spy.rb
@@ -1,0 +1,19 @@
+class PIDFileSpy
+
+  attr_reader :pid, :write_called, :remove_called
+
+  def initialize(pid)
+    @pid = pid
+    @write_called = false
+    @remove_called = false
+  end
+
+  def write
+    @write_called = true
+  end
+
+  def remove
+    @remove_called = true
+  end
+
+end

--- a/test/unit/process_signal_tests.rb
+++ b/test/unit/process_signal_tests.rb
@@ -1,0 +1,60 @@
+require 'assert'
+require 'sanford/process_signal'
+
+require 'test/support/pid_file_spy'
+
+class Sanford::ProcessSignal
+
+  class UnitTests < Assert::Context
+    desc "Sanford::ProcessSignal"
+    setup do
+      @server = TestServer.new
+      @signal = Factory.string
+
+      @pid_file_spy = PIDFileSpy.new(Factory.integer)
+      Assert.stub(Sanford::PIDFile, :new).with(@server.pid_file) do
+        @pid_file_spy
+      end
+
+      @process_signal = Sanford::ProcessSignal.new(@server, @signal)
+    end
+    subject{ @process_signal }
+
+    should have_readers :signal, :pid
+    should have_imeths :send
+
+    should "know its signal and pid" do
+      assert_equal @signal, subject.signal
+      assert_equal @pid_file_spy.pid, subject.pid
+    end
+
+  end
+
+  class SendTests < UnitTests
+    desc "when sent"
+    setup do
+      @kill_called = false
+      Assert.stub(::Process, :kill).with(@signal, @pid_file_spy.pid) do
+        @kill_called = true
+      end
+
+      @process_signal.send
+    end
+
+    should "have used process kill to send the signal to the PID" do
+      assert_true @kill_called
+    end
+
+  end
+
+  class TestServer
+    include Sanford::Server
+
+    name Factory.string
+    ip Factory.string
+    port Factory.integer
+    pid_file Factory.file_path
+
+  end
+
+end

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'sanford/process'
 
 require 'sanford/server'
+require 'test/support/pid_file_spy'
 
 class Sanford::Process
 
@@ -30,7 +31,7 @@ class Sanford::Process
 
       @server_spy = ServerSpy.new
 
-      @pid_file_spy = PIDFileSpy.new
+      @pid_file_spy = PIDFileSpy.new(Factory.integer)
       Assert.stub(Sanford::PIDFile, :new).with(@server_spy.pid_file) do
         @pid_file_spy
       end
@@ -409,24 +410,6 @@ class Sanford::Process
     def join
       @join_called = true
       @on_join_proc.call
-    end
-  end
-
-  class PIDFileSpy
-    attr_reader :pid, :write_called, :remove_called
-
-    def initialize
-      @pid = Factory.integer
-      @write_called = false
-      @remove_called = false
-    end
-
-    def write
-      @write_called = true
-    end
-
-    def remove
-      @remove_called = true
     end
   end
 


### PR DESCRIPTION
This adds logic for sending signals to a Sanford process. This
will be used by the CLI to stop, halt or restart a Sanford
process. It will try and find an existing PID file for the process
and send the signal to the PID stored in it. This replaces logic
that currently exists in the `Manager`.

@kellyredding - Ready for review.
