### PR TITLE
Remove `Runner.run` and `ServiceHandler.run`

### DIFF
--- a/lib/sanford/runner.rb
+++ b/lib/sanford/runner.rb
@@ -9,7 +9,6 @@ module Sanford
 
     def self.included(klass)
       klass.class_eval do
-        extend ClassMethods
         include InstanceMethods
       end
     end
@@ -59,15 +58,6 @@ module Sanford
 
       def build_response(args)
         Sanford::Protocol::Response.new(args.status, args.data) if args
-      end
-
-    end
-
-    module ClassMethods
-
-      def run(handler_class, params = nil, logger = nil)
-        request = Sanford::Protocol::Request.new('name', params || {})
-        self.new(handler_class, request, logger).run
       end
 
     end

--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -68,10 +68,6 @@ module Sanford
         )
       end
 
-      def run_handler(handler_class, params = nil)
-        handler_class.run(params || {}, self.logger)
-      end
-
       def halt(*args); @sanford_runner.halt(*args); end
       def request;     @sanford_runner.request;     end
       def params;      self.request.params;         end
@@ -98,10 +94,6 @@ module Sanford
     end
 
     module ClassMethods
-
-      def run(params = nil, logger = nil)
-        SanfordRunner.run(self, params || {}, logger)
-      end
 
       def before_callbacks;      @before_callbacks      ||= []; end
       def after_callbacks;       @after_callbacks       ||= []; end

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -16,7 +16,6 @@ module Sanford::Runner
     end
     subject{ @runner }
 
-    should have_cmeths :run
     should have_readers :handler_class, :request, :logger, :handler
     should have_imeths :init, :init!, :run, :run!
     should have_imeths :halt, :catch_halt

--- a/test/unit/sanford_runner_tests.rb
+++ b/test/unit/sanford_runner_tests.rb
@@ -17,15 +17,6 @@ class Sanford::SanfordRunner
       assert_includes Sanford::Runner, subject
     end
 
-    should "be able to build a runner with a handler class and params and run it" do
-      response = nil
-      assert_nothing_raised do
-        response = subject.run(BasicServiceHandler, {})
-      end
-
-      assert_equal 200, response.code
-    end
-
   end
 
   class InitTests < UnitTests

--- a/test/unit/service_handler_tests.rb
+++ b/test/unit/service_handler_tests.rb
@@ -17,7 +17,6 @@ module Sanford::ServiceHandler
     end
     subject{ @handler_class }
 
-    should have_imeths :run
     should have_imeths :before_callbacks, :after_callbacks
     should have_imeths :before_init_callbacks, :after_init_callbacks
     should have_imeths :before_run_callbacks,  :after_run_callbacks
@@ -31,15 +30,6 @@ module Sanford::ServiceHandler
     should "disallow certain template extensions" do
       exp = Sanford::TemplateSource::DISALLOWED_ENGINE_EXTS
       assert_equal exp, subject::DISALLOWED_TEMPLATE_EXTS
-    end
-
-    should "allow running a handler class with the class method #run" do
-      response = HaltServiceHandler.run({
-        'code'    => 648,
-        'data'    => true
-      })
-      assert_equal 648,   response.code
-      assert_equal true,  response.data
     end
 
     should "return an empty array by default using `before_callbacks`" do
@@ -342,16 +332,6 @@ module Sanford::ServiceHandler
       assert_raises ArgumentError do
         test_runner(RenderHandler, 'template_name' => 'test_disallowed_template').run
       end
-    end
-
-  end
-
-  class RunHandlerTests < UnitTests
-    desc "run_handler helper"
-
-    should "allow easily running another handler" do
-      response = test_runner(RunOtherHandler).run
-      assert_equal 'RunOtherHandler', response.data
     end
 
   end


### PR DESCRIPTION
This removes the `Runner.run` and the `ServiceHandler.run` class
methods. These were a neat feature but haven't really worked out
or been used. Since these haven't been used, this removes them so
they no longer have to be maintained. With planned changes to the
`Runner.new` args, this avoids having to update both of these
methods to using the new args.

@kellyredding - Ready for review. I'm working through changing the `Runner.new` to take a server's config data as its third arg and these methods were annoying to update. I didn't want to change them to expect a server's config data to be passed to them, so either I have to build a config data in the methods and then pass it to the sanford runner or change the runner logic to conditionally build a config data if one isn't passed. Since we haven't had any use for these methods, I thought it would be better to remove them instead of taking the time to get them to work.
