### PR TITLE
`TestRunner`, dependency inject attributes on service handler

### DIFF
--- a/lib/sanford/runner.rb
+++ b/lib/sanford/runner.rb
@@ -21,14 +21,6 @@ module Sanford
         @handler_class, @request = handler_class, request
         @logger = logger || Sanford.config.logger
         @handler = @handler_class.new(self)
-        self.init
-      end
-
-      def init
-        self.init!
-      end
-
-      def init!
       end
 
       def run

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -17,13 +17,11 @@ module Sanford::Runner
     subject{ @runner }
 
     should have_readers :handler_class, :request, :logger, :handler
-    should have_imeths :init, :init!, :run, :run!
+    should have_imeths :run, :run!
     should have_imeths :halt, :catch_halt
 
     should "not implement the run behavior" do
-      assert_raises NotImplementedError do
-        subject.run
-      end
+      assert_raises(NotImplementedError){ subject.run }
     end
 
   end

--- a/test/unit/service_handler_tests.rb
+++ b/test/unit/service_handler_tests.rb
@@ -194,7 +194,7 @@ module Sanford::ServiceHandler
     desc "when halted"
 
     should "return a response with the status code and the passed data" do
-      runner = test_runner(HaltServiceHandler, {
+      runner = test_runner(HaltServiceHandler, :params => {
         'code'    => 648,
         'data'    => true
       })
@@ -206,7 +206,7 @@ module Sanford::ServiceHandler
     end
 
     should "return a response with the status code for the named status and the passed message" do
-      runner = test_runner(HaltServiceHandler, {
+      runner = test_runner(HaltServiceHandler, :params => {
         'code'    => 'ok',
         'message' => 'test message'
       })
@@ -223,7 +223,7 @@ module Sanford::ServiceHandler
     desc "when halted at different points"
 
     should "not call `init!, `after_init`, `run!` or run's callbacks when `before_init` halts" do
-      runner = test_runner(HaltingBehaviorServiceHandler, {
+      runner = test_runner(HaltingBehaviorServiceHandler, :params => {
         'when' => 'before_init'
       })
       response = runner.response
@@ -239,7 +239,7 @@ module Sanford::ServiceHandler
     end
 
     should "not call `after_init`, `run!` or its callbacks when `init!` halts" do
-      runner = test_runner(HaltingBehaviorServiceHandler, {
+      runner = test_runner(HaltingBehaviorServiceHandler, :params => {
         'when' => 'init!'
       })
       response = runner.response
@@ -255,7 +255,7 @@ module Sanford::ServiceHandler
     end
 
     should "not call `run!` or its callbacks when `after_init` halts" do
-      runner = test_runner(HaltingBehaviorServiceHandler, {
+      runner = test_runner(HaltingBehaviorServiceHandler, :params => {
         'when' => 'after_init'
       })
       response = runner.response
@@ -271,7 +271,7 @@ module Sanford::ServiceHandler
     end
 
     should "not call `run!` or `after_run` when `before_run` halts" do
-      runner = test_runner(HaltingBehaviorServiceHandler, {
+      runner = test_runner(HaltingBehaviorServiceHandler, :params => {
         'when' => 'before_run'
       })
       response = runner.run
@@ -287,7 +287,7 @@ module Sanford::ServiceHandler
     end
 
     should "not call `after_run` when `run!` halts" do
-      runner = test_runner(HaltingBehaviorServiceHandler, {
+      runner = test_runner(HaltingBehaviorServiceHandler, :params => {
         'when' => 'run!'
       })
       response = runner.run
@@ -303,7 +303,7 @@ module Sanford::ServiceHandler
     end
 
     should "call `init`, `run` and their callbacks when `after_run` halts" do
-      runner = test_runner(HaltingBehaviorServiceHandler, {
+      runner = test_runner(HaltingBehaviorServiceHandler, :params => {
         'when' => 'after_run'
       })
       response = runner.run
@@ -324,13 +324,17 @@ module Sanford::ServiceHandler
     desc "render helper method"
 
     should "render template files" do
-      response = test_runner(RenderHandler, 'template_name' => 'test_template').run
+      response = test_runner(RenderHandler, :params => {
+        'template_name' => 'test_template'
+      }).run
       assert_equal ['test_template', 'RenderHandler', {}], response.data
     end
 
     should "not render any template files with a disallowed template ext" do
       assert_raises ArgumentError do
-        test_runner(RenderHandler, 'template_name' => 'test_disallowed_template').run
+        test_runner(RenderHandler, :params => {
+          'template_name' => 'test_disallowed_template'
+        }).run
       end
     end
 

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -1,0 +1,193 @@
+require 'assert'
+require 'sanford/test_runner'
+
+class Sanford::TestRunner
+
+  class UnitTests < Assert::Context
+    desc "Sanford::TestRunner"
+    setup do
+      @handler_class = TestServiceHandler
+      @logger = Factory.string
+      @params = { :something => Factory.string }
+      @request = Sanford::Protocol::Request.new(Factory.string, {
+        :other => Factory.string
+      })
+      @handler_flag = Factory.boolean
+
+      @runner_class = Sanford::TestRunner
+    end
+    subject{ @runner_class }
+
+    should "be a runner" do
+      assert_includes Sanford::Runner, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @runner = @runner_class.new(@handler_class, {
+        :logger => @logger,
+        :params => @params,
+        :flag => @handler_flag
+      })
+    end
+    subject{ @runner }
+
+    should have_readers :response
+    should have_imeths :run, :run!
+
+    should "know its logger" do
+      assert_equal @logger, subject.logger
+    end
+
+    should "build a request using the params" do
+      assert_equal 'name', subject.request.name
+      assert_equal @params, subject.request.params
+    end
+
+    should "write extra args to its service handler" do
+      assert_equal @handler_flag, subject.handler.flag
+    end
+
+    should "take a request over params if provided" do
+      test_runner = @runner_class.new(@handler_class, {
+        :params => @params,
+        :request => @request
+      })
+      assert_equal @request, test_runner.request
+    end
+
+    should "default its logger, params and request" do
+      test_runner = @runner_class.new(@handler_class)
+      assert_instance_of Sanford::NullLogger, test_runner.logger
+      expected = Sanford::Protocol::Request.new('name', {})
+      assert_equal expected, test_runner.request
+    end
+
+    should "have called init on its service handler" do
+      assert_true subject.handler.init_called
+    end
+
+    should "not have a response by default" do
+      assert_nil subject.response
+    end
+
+    should "raise an invalid error when not passed a service handler" do
+      assert_raises(Sanford::InvalidServiceHandlerError) do
+        @runner_class.new(Class.new)
+      end
+    end
+
+  end
+
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @response = @runner.run
+    end
+    subject{ @response }
+
+    should "know its response" do
+      assert_equal subject, @runner.response
+      assert_instance_of Sanford::Protocol::Response, subject
+    end
+
+    should "have called run on its service handler" do
+      assert_true @runner.handler.run_called
+    end
+
+  end
+
+  class RunWithInvalidResponseTests < InitTests
+    desc "and run with an invalid response"
+    setup do
+      @runner.handler.response = Class.new
+    end
+
+    should "raise a serialization error" do
+      assert_raises(BSON::InvalidDocument){ subject.run }
+    end
+
+  end
+
+  class InitThatHaltsTests < UnitTests
+    desc "when init with a handler that halts in its init"
+    setup do
+      @runner = @runner_class.new(HaltServiceHandler)
+    end
+    subject{ @runner }
+
+    should "know the response from the init halting" do
+      assert_instance_of Sanford::Protocol::Response, subject.response
+      assert_equal subject.handler.response_code, subject.response.code
+    end
+
+  end
+
+  class RunWithInitThatHaltsTests < InitThatHaltsTests
+    desc "is run"
+    setup do
+      @response = @runner.run
+    end
+    subject{ @response }
+
+    should "not call run on the service handler" do
+      assert_false @runner.handler.run_called
+    end
+
+    should "return the response from the init halting" do
+      assert_instance_of Sanford::Protocol::Response, subject
+      assert_equal @runner.handler.response_code, subject.code
+    end
+
+  end
+
+  class RunWithInvalidResponseFromInitHaltTests < UnitTests
+    desc "when init with a handler that halts in its init an invalid response"
+
+    should "raise a serialization error" do
+      assert_raises(BSON::InvalidDocument) do
+        @runner_class.new(HaltServiceHandler, :response_data => Class.new)
+      end
+    end
+
+  end
+
+  class TestServiceHandler
+    include Sanford::ServiceHandler
+
+    attr_reader :init_called, :run_called
+    attr_accessor :flag, :response
+
+    def init!
+      @init_called = true
+      @run_called = false
+    end
+
+    def run!
+      @run_called = true
+      @response || Factory.boolean
+    end
+  end
+
+  class HaltServiceHandler
+    include Sanford::ServiceHandler
+
+    attr_reader :run_called
+    attr_accessor :response_code, :response_data
+
+    def init!
+      @run_called = false
+      @response_code ||= Factory.integer
+      @response_data ||= Factory.string
+      halt(@response_code, :data => @response_data)
+    end
+
+    def run!
+      @run_called = true
+    end
+  end
+
+end


### PR DESCRIPTION
This adds dependency injecting attributes on service handlers
with the `TestRunner`. This allows passing more than just params
when using the `test_runner` test helper. The `TestRunner` now
takes a hash of args and it will pull out keys for params, logger
and a request. Any other keys in the hash will be used to try and
write their values to the service handler it builds. This allows
dependency injecting values when a handler is built.

This also changes `Runner` to no longer have an `init` and `init!`
methods. These were originally done when `Runner` was a mixin that
could be used and configured on servers. This is no longer the case
and they were only used by the test runner so there's really no
need to keep these methods.

Finally, this moves the serializing of a response. It is now done
whenever the test runner builds a response, either from initing
or running the service handler, not just when its run. This makes
sure that when a handler halts in its `init!` or a callback, we
also try to serialize these responses to ensure they don't throw
any errors.

Finally, this adds unit tests for the test runner. Previously it
was only tested implicitly via the service handler.

Closes #106 

@kellyredding - Ready for review. 
