### PR TITLE
Rework `CLI` to use `ConfigFile, `Process` and `ProcessSignal`

### DIFF
--- a/bench/config.sanford
+++ b/bench/config.sanford
@@ -1,13 +1,16 @@
-class BenchHost
-  include Sanford::Host
+class BenchServer
+  include Sanford::Server
 
+  name     'bench'
   port     59284
-  pid_file File.expand_path("../../tmp/bench_host.pid", __FILE__)
+  pid_file File.expand_path("../../tmp/bench_server.pid", __FILE__)
 
-  logger           Logger.new(STDOUT)
-  verbose_logging  false
+  logger          Logger.new(STDOUT)
+  verbose_logging false
 
-  service 'simple', 'BenchHost::Simple'
+  router do
+    service 'simple', 'BenchServer::Simple'
+  end
 
   class Simple
     include Sanford::ServiceHandler
@@ -22,3 +25,5 @@ class BenchHost
   end
 
 end
+
+run BenchServer.new

--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,38 +2,32 @@ Running benchmark report...
 
 Hitting "simple" service with {}, 10000 times
 ....................................................................................................
-Total Time:   5436.7293ms
-Average Time:    0.5436ms
-Min Time:        0.3609ms
-Max Time:       40.8990ms
+Total Time:   5467.3860ms
+Average Time:    0.5467ms
+Min Time:        0.3580ms
+Max Time:       32.5438ms
 
 Distribution (number of requests):
-  0ms: 9922
-    0.3ms: 5113
-    0.4ms: 3958
-    0.5ms: 411
-    0.6ms: 281
-    0.7ms: 108
-    0.8ms: 29
-    0.9ms: 22
-  1ms: 35
-    1.0ms: 8
-    1.1ms: 11
+  0ms: 9935
+    0.3ms: 4996
+    0.4ms: 4369
+    0.5ms: 352
+    0.6ms: 124
+    0.7ms: 51
+    0.8ms: 35
+    0.9ms: 8
+  1ms: 21
+    1.0ms: 4
+    1.1ms: 2
     1.2ms: 6
-    1.3ms: 4
+    1.3ms: 5
     1.4ms: 3
-    1.5ms: 2
-    1.7ms: 1
-  2ms: 2
-  12ms: 2
-  26ms: 1
-  28ms: 6
-  29ms: 19
-  30ms: 6
-  31ms: 2
-  32ms: 1
-  33ms: 1
-  34ms: 2
-  40ms: 1
+    1.6ms: 1
+  27ms: 1
+  28ms: 9
+  29ms: 23
+  30ms: 8
+  31ms: 1
+  32ms: 2
 
 Done running benchmark report

--- a/bench/tasks.rb
+++ b/bench/tasks.rb
@@ -7,22 +7,22 @@ namespace :bench do
   namespace :server do
 
     task :load do
-      ENV['SANFORD_SERVICES_FILE'] = 'bench/services'
+      @config_file = 'bench/config.sanford'
     end
 
     desc "Run the bench server"
     task :run => :load do
-      Kernel.exec("bundle exec sanford run")
+      Kernel.exec("bundle exec sanford #{@config_file} run")
     end
 
     desc "Start a daemonized bench server"
     task :start => :load do
-      Kernel.system("bundle exec sanford start")
+      Kernel.system("bundle exec sanford #{@config_file} start")
     end
 
     desc "Stop the bench server"
     task :stop => :load do
-      Kernel.system("bundle exec sanford stop")
+      Kernel.system("bundle exec sanford #{@config_file} stop")
     end
 
   end

--- a/lib/sanford/process.rb
+++ b/lib/sanford/process.rb
@@ -7,7 +7,8 @@ module Sanford
     attr_reader :server, :name, :pid_file, :restart_cmd
     attr_reader :server_ip, :server_port, :server_fd, :client_fds
 
-    def initialize(server, daemonize = false)
+    def initialize(server, options = nil)
+      options ||= {}
       @server = server
       @logger = @server.logger
       @name = "sanford-#{@server.name}"
@@ -18,10 +19,11 @@ module Sanford
       @server_port = ignore_if_blank(ENV['SANFORD_PORT']){ |v| v.to_i }
       @server_fd = ignore_if_blank(ENV['SANFORD_SERVER_FD']){ |v| v.to_i }
       @listen_args = @server_fd ? [ @server_fd ] : [ @server_ip, @server_port ]
+      @listen_args.compact!
 
       @client_fds = (ENV['SANFORD_CLIENT_FDS'] || "").split(',').map(&:to_i)
 
-      @daemonize = !!daemonize
+      @daemonize = !!options[:daemonize]
       @skip_daemonize = !!ignore_if_blank(ENV['SANFORD_SKIP_DAEMONIZE'])
     end
 

--- a/test/unit/cli_tests.rb
+++ b/test/unit/cli_tests.rb
@@ -1,0 +1,187 @@
+require 'assert'
+require 'sanford/cli'
+
+class Sanford::CLI
+
+  class UnitTests < Assert::Context
+    desc "Sanford::CLI"
+    setup do
+      @kernel_spy = KernelSpy.new
+      @file_path = Factory.file_path
+
+      @server = TestServer.new
+
+      @config_file = FakeConfigFile.new(@server)
+      Assert.stub(Sanford::ConfigFile, :new).with(@file_path){ @config_file }
+
+      @cli = Sanford::CLI.new(@kernel_spy)
+    end
+    subject{ @cli }
+
+    should have_cmeths :run
+    should have_imeths :run
+
+  end
+
+  class CommandTests < UnitTests
+    setup do
+      @process_spy = ProcessSpy.new
+      @process_signal_spy = ProcessSignalSpy.new
+    end
+
+  end
+
+  class DefaultsTests < CommandTests
+    desc "with no command or file path"
+    setup do
+      file_path = 'config.sanford'
+      Assert.stub(Sanford::ConfigFile, :new).with(file_path){ @config_file }
+      Assert.stub(Sanford::Process, :new).with(@server, :daemonize => false) do
+        @process_spy
+      end
+
+      @cli.run
+    end
+
+    should "have defaulted the command and file path" do
+      assert_true @process_spy.run_called
+    end
+
+  end
+
+  class RunTests < CommandTests
+    desc "with the run command"
+    setup do
+      Assert.stub(Sanford::Process, :new).with(@server, :daemonize => false) do
+        @process_spy
+      end
+
+      @cli.run(@file_path, 'run')
+    end
+
+    should "have built and run a non-daemonized process" do
+      assert_true @process_spy.run_called
+    end
+
+  end
+
+  class StartTests < CommandTests
+    desc "with the start command"
+    setup do
+      Assert.stub(Sanford::Process, :new).with(@server, :daemonize => true) do
+        @process_spy
+      end
+
+      @cli.run(@file_path, 'start')
+    end
+
+    should "have built and run a daemonized process" do
+      assert_true @process_spy.run_called
+    end
+
+  end
+
+  class StopTests < CommandTests
+    desc "with the stop command"
+    setup do
+      Assert.stub(Sanford::ProcessSignal, :new).with(@server, 'TERM') do
+        @process_signal_spy
+      end
+
+      @cli.run(@file_path, 'stop')
+    end
+
+    should "have built and sent a TERM signal" do
+      assert_true @process_signal_spy.send_called
+    end
+
+  end
+
+  class RestartTests < CommandTests
+    desc "with the restart command"
+    setup do
+      Assert.stub(Sanford::ProcessSignal, :new).with(@server, 'USR2') do
+        @process_signal_spy
+      end
+
+      @cli.run(@file_path, 'restart')
+    end
+
+    should "have built and sent a USR2 signal" do
+      assert_true @process_signal_spy.send_called
+    end
+
+  end
+
+  class InvalidCommandTests < UnitTests
+    desc "with an invalid command"
+    setup do
+      @command = Factory.string
+      @cli.run(@file_path, @command)
+    end
+
+    should "output the error with the help" do
+      expected = "#{@command.inspect} is not a valid command"
+      assert_includes expected, @kernel_spy.output
+      assert_includes "Usage: sanford", @kernel_spy.output
+    end
+
+  end
+
+  class KernelSpy
+    attr_reader :exit_status
+
+    def initialize
+      @output = StringIO.new
+      @exit_status = nil
+    end
+
+    def output
+      @output.rewind
+      @output.read
+    end
+
+    def puts(message)
+      @output.puts(message)
+    end
+
+    def exit(code)
+      @exit_status = code
+    end
+  end
+
+  class TestServer
+    include Sanford::Server
+
+    name Factory.string
+    ip Factory.string
+    port Factory.integer
+  end
+
+  FakeConfigFile = Struct.new(:server)
+
+  class ProcessSpy
+    attr_reader :run_called
+
+    def initialize
+      @run_called = false
+    end
+
+    def run
+      @run_called = true
+    end
+  end
+
+  class ProcessSignalSpy
+    attr_reader :send_called
+
+    def initialize
+      @send_called = false
+    end
+
+    def send
+      @send_called = true
+    end
+  end
+
+end

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -107,7 +107,7 @@ class Sanford::Process
     end
 
     should "daemonize if turned on" do
-      process = @process_class.new(@server_spy, true)
+      process = @process_class.new(@server_spy, :daemonize => true)
       assert_true process.daemonize?
     end
 
@@ -115,13 +115,13 @@ class Sanford::Process
       ENV['SANFORD_SKIP_DAEMONIZE'] = 'yes'
       process = @process_class.new(@server_spy)
       assert_false process.daemonize?
-      process = @process_class.new(@server_spy, true)
+      process = @process_class.new(@server_spy, :daemonize => true)
       assert_false process.daemonize?
     end
 
     should "ignore blank env values for skip daemonize" do
       ENV['SANFORD_SKIP_DAEMONIZE'] = ''
-      process = @process_class.new(@server_spy, true)
+      process = @process_class.new(@server_spy, :daemonize => true)
       assert_true process.daemonize?
     end
 
@@ -173,7 +173,7 @@ class Sanford::Process
 
     should "have started the server listening" do
       assert_true @server_spy.listen_called
-      assert_equal [ nil, nil ], @server_spy.listen_args
+      assert_equal [], @server_spy.listen_args
     end
 
     should "have set the process name" do


### PR DESCRIPTION
This reworks the `CLI` to use all the new logic. It now expects
a config file path and builds a `ConfigFile` to evaluate it. The
server from the `ConfigFile` is then either passed to a `Process`
or `ProcessSignal` depending on the command. Sanford supports the
same commands it did previously: run, start, stop and restart.
This makes all of Sanford's old manager, host and host data logic
no longer needed and it will be removed in a future commit.

This also fixes an integration bug. The process was passing a `nil`
ip and port to `Server#listen`. This is invalid and will cause the
server to try to bind to an ip and port of `nil`. This is fixed
by compacting the `nil` values from the listen args the process
builds.

@kellyredding - Ready for review.
