### PR TITLE
Rename `Server::ConfigData` to `ServerData`

### DIFF
--- a/lib/sanford/error_handler.rb
+++ b/lib/sanford/error_handler.rb
@@ -5,12 +5,12 @@ module Sanford
 
   class ErrorHandler
 
-    attr_reader :exception, :config_data, :request
+    attr_reader :exception, :server_data, :request
     attr_reader :error_procs
 
-    def initialize(exception, config_data = nil, request = nil)
-      @exception, @config_data, @request = exception, config_data, request
-      @error_procs = @config_data ? @config_data.error_procs.reverse : []
+    def initialize(exception, server_data = nil, request = nil)
+      @exception, @server_data, @request = exception, server_data, request
+      @error_procs = @server_data ? @server_data.error_procs.reverse : []
     end
 
     # The exception that we are generating a response for can change in the case
@@ -24,7 +24,7 @@ module Sanford
       @error_procs.each do |error_proc|
         result = nil
         begin
-          result = error_proc.call(@exception, @config_data, @request)
+          result = error_proc.call(@exception, @server_data, @request)
         rescue StandardError => proc_exception
           @exception = proc_exception
         end

--- a/lib/sanford/server_data.rb
+++ b/lib/sanford/server_data.rb
@@ -1,0 +1,47 @@
+module Sanford
+
+  class ServerData
+
+    # The server uses this to "compile" its configuration for speed. NsOptions
+    # is relatively slow everytime an option is read. To avoid this, we read the
+    # options one time here and memoize their values. This way, we don't pay the
+    # NsOptions overhead when reading them while handling a request.
+
+    attr_reader :name
+    attr_reader :ip, :port
+    attr_reader :pid_file
+    attr_reader :logger, :verbose_logging
+    attr_reader :receives_keep_alive
+    attr_reader :error_procs
+    attr_reader :routes
+    attr_reader :template_source
+
+    def initialize(args = nil)
+      args ||= {}
+      @name = args[:name]
+      @ip   = args[:ip]
+      @port = args[:port]
+      @pid_file = args[:pid_file]
+      @logger = args[:logger]
+      @verbose_logging = !!args[:verbose_logging]
+      @receives_keep_alive = !!args[:receives_keep_alive]
+      @error_procs = args[:error_procs] || []
+      @routes = build_routes(args[:routes] || [])
+      @template_source = args[:template_source]
+    end
+
+    def route_for(name)
+      @routes[name] || raise(NotFoundError, "no service named '#{name}'")
+    end
+
+    private
+
+    def build_routes(routes)
+      routes.inject({}){ |h, route| h.merge(route.name => route) }
+    end
+
+  end
+
+  NotFoundError = Class.new(RuntimeError)
+
+end

--- a/lib/sanford/worker.rb
+++ b/lib/sanford/worker.rb
@@ -12,15 +12,15 @@ module Sanford
       :request, :handler_class, :response, :exception, :time_taken
     )
 
-    attr_reader :config_data, :connection
+    attr_reader :server_data, :connection
     attr_reader :logger
 
-    def initialize(config_data, connection)
-      @config_data = config_data
+    def initialize(server_data, connection)
+      @server_data = server_data
       @connection = connection
       @logger = Sanford::Logger.new(
-        @config_data.logger,
-        @config_data.verbose_logging
+        @server_data.logger,
+        @server_data.verbose_logging
       )
     end
 
@@ -45,14 +45,14 @@ module Sanford
         self.log_request(request)
         service.request = request
 
-        route = @config_data.route_for(request.name)
+        route = @server_data.route_for(request.name)
         self.log_handler_class(route.handler_class)
         service.handler_class = route.handler_class
 
-        response = route.run(request, @config_data.logger)
+        response = route.run(request, @server_data)
         service.response = response
       rescue StandardError => exception
-        self.handle_exception(service, exception, @config_data)
+        self.handle_exception(service, exception, @server_data)
       ensure
         self.write_response(service)
       end
@@ -70,10 +70,10 @@ module Sanford
       service
     end
 
-    def handle_exception(service, exception, config_data = nil)
+    def handle_exception(service, exception, server_data = nil)
       error_handler = Sanford::ErrorHandler.new(
         exception,
-        config_data,
+        server_data,
         service.request
       )
       service.response  = error_handler.run

--- a/test/support/app_server.rb
+++ b/test/support/app_server.rb
@@ -28,9 +28,9 @@ class AppServer
     service 'custom_error', 'CustomError'
   end
 
-  error do |exception, config_data, request|
+  error do |exception, server_data, request|
     if request && request.name == 'custom_error'
-      data = "The server on #{config_data.ip}:#{config_data.port} " \
+      data = "The server on #{server_data.ip}:#{server_data.port} " \
              "threw a #{exception.class}."
       Sanford::Protocol::Response.new(200, data)
     end

--- a/test/system/server_tests.rb
+++ b/test/system/server_tests.rb
@@ -181,7 +181,7 @@ module Sanford::Server
       ENV['SANFORD_TIMEOUT'] = '0.1'
 
       # keep-alive messes up testing this, so we disable it for this test
-      Assert.stub(@server.config_data, :receives_keep_alive){ false }
+      Assert.stub(@server.server_data, :receives_keep_alive){ false }
 
       @client.delay = 0.5
       @client.set_request('echo', :message => Factory.string)

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -1,7 +1,7 @@
 require 'assert'
 require 'sanford/error_handler'
 
-require 'sanford/server'
+require 'sanford/server_data'
 
 class Sanford::ErrorHandler
 
@@ -9,12 +9,12 @@ class Sanford::ErrorHandler
     desc "Sanford::ErrorHandler"
     setup do
       @exception = RuntimeError.new('test')
-      @config_data = Sanford::Server::ConfigData.new
-      @error_handler = Sanford::ErrorHandler.new(@exception, @config_data)
+      @server_data = Sanford::ServerData.new
+      @error_handler = Sanford::ErrorHandler.new(@exception, @server_data)
     end
     subject{ @error_handler }
 
-    should have_imeths :exception, :config_data, :request, :run
+    should have_imeths :exception, :server_data, :request, :run
 
     should "return a Sanford::Protocol::Response with `run`" do
       assert_instance_of Sanford::Protocol::Response, subject.run
@@ -38,8 +38,8 @@ class Sanford::ErrorHandler
       error_proc = proc do |exception, host_data, request|
         Sanford::Protocol::Response.new([ 567, 'custom message'], 'custom data')
       end
-      config_data = Sanford::Server::ConfigData.new(:error_procs => [ error_proc ])
-      response = Sanford::ErrorHandler.new(@exception, config_data).run
+      server_data = Sanford::ServerData.new(:error_procs => [ error_proc ])
+      response = Sanford::ErrorHandler.new(@exception, server_data).run
 
       assert_equal 567, response.code
       assert_equal 'custom message', response.status.message
@@ -47,8 +47,8 @@ class Sanford::ErrorHandler
     end
 
     should "use an integer returned by the error proc to generate a protocol response" do
-      config_data = Sanford::Server::ConfigData.new(:error_procs => [ proc{ 345 } ])
-      response = Sanford::ErrorHandler.new(@exception, config_data).run
+      server_data = Sanford::ServerData.new(:error_procs => [ proc{ 345 } ])
+      response = Sanford::ErrorHandler.new(@exception, server_data).run
 
       assert_equal 345, response.code
       assert_nil response.status.message
@@ -56,10 +56,10 @@ class Sanford::ErrorHandler
     end
 
     should "use a symbol returned by the error proc to generate a protocol response" do
-      config_data = Sanford::Server::ConfigData.new({
+      server_data = Sanford::ServerData.new({
         :error_procs => [ proc{ :not_found } ]
       })
-      response = Sanford::ErrorHandler.new(@exception, config_data).run
+      response = Sanford::ErrorHandler.new(@exception, server_data).run
 
       assert_equal 404, response.code
       assert_nil response.status.message
@@ -67,8 +67,8 @@ class Sanford::ErrorHandler
     end
 
     should "use the default behavior if the error proc doesn't return a valid response result" do
-      config_data = Sanford::Server::ConfigData.new(:error_procs => [ proc{ true } ])
-      response = Sanford::ErrorHandler.new(@exception, config_data).run
+      server_data = Sanford::ServerData.new(:error_procs => [ proc{ true } ])
+      response = Sanford::ErrorHandler.new(@exception, server_data).run
 
       assert_equal 500, response.code
       assert_equal 'An unexpected error occurred.', response.status.message
@@ -76,10 +76,10 @@ class Sanford::ErrorHandler
 
     should "use the default behavior for an exception raised by the error proc " \
            "and ignore the original exception" do
-      config_data = Sanford::Server::ConfigData.new({
+      server_data = Sanford::ServerData.new({
         :error_procs => [ proc{ raise Sanford::NotFoundError } ]
       })
-      response = Sanford::ErrorHandler.new(@exception, config_data).run
+      response = Sanford::ErrorHandler.new(@exception, server_data).run
 
       assert_equal 404, response.code
       assert_nil response.status.message
@@ -93,7 +93,7 @@ class Sanford::ErrorHandler
 
     should "build a 400 response with a protocol BadMessageError" do
       exception = generate_exception(Sanford::Protocol::BadMessageError, 'bad message')
-      response = Sanford::ErrorHandler.new(exception, @config_data).run
+      response = Sanford::ErrorHandler.new(exception, @server_data).run
 
       assert_equal 400, response.code
       assert_equal 'bad message', response.status.message
@@ -101,7 +101,7 @@ class Sanford::ErrorHandler
 
     should "build a 400 response with a protocol BadRequestError" do
       exception = generate_exception(Sanford::Protocol::BadRequestError, 'bad request')
-      response = Sanford::ErrorHandler.new(exception, @config_data).run
+      response = Sanford::ErrorHandler.new(exception, @server_data).run
 
       assert_equal 400, response.code
       assert_equal 'bad request', response.status.message
@@ -109,14 +109,14 @@ class Sanford::ErrorHandler
 
     should "build a 404 response with a NotFoundError" do
       exception = generate_exception(Sanford::NotFoundError, 'not found')
-      response = Sanford::ErrorHandler.new(exception, @config_data).run
+      response = Sanford::ErrorHandler.new(exception, @server_data).run
 
       assert_equal 404, response.code
       assert_nil response.status.message
     end
 
     should "build a 500 response with all other exceptions" do
-      response = Sanford::ErrorHandler.new(RuntimeError.new('test'), @config_data).run
+      response = Sanford::ErrorHandler.new(RuntimeError.new('test'), @server_data).run
 
       assert_equal 500, response.code
       assert_equal 'An unexpected error occurred.', response.status.message
@@ -128,14 +128,14 @@ class Sanford::ErrorHandler
     desc "with multiple error procs"
     setup do
       @first_called, @second_called, @third_called = nil, nil, nil
-      @config_data = Sanford::Server::ConfigData.new({
+      @server_data = Sanford::ServerData.new({
         :error_procs => [ first_proc, second_proc, third_proc ]
       })
     end
 
     should "call every error proc" do
       exception = RuntimeError.new('test')
-      @error_handler = Sanford::ErrorHandler.new(exception, @config_data)
+      @error_handler = Sanford::ErrorHandler.new(exception, @server_data)
       @error_handler.run
 
       assert_equal true, @first_called
@@ -146,14 +146,14 @@ class Sanford::ErrorHandler
     should "should return the response of the last configured error proc " \
            "that returned a valid response" do
       exception = RuntimeError.new('test')
-      @error_handler = Sanford::ErrorHandler.new(exception, @config_data)
+      @error_handler = Sanford::ErrorHandler.new(exception, @server_data)
       response = @error_handler.run
 
       # use the second proc's generated response
       assert_equal 987, response.code
 
       exception = generate_exception(Sanford::NotFoundError, 'not found')
-      @error_handler = Sanford::ErrorHandler.new(exception, @config_data)
+      @error_handler = Sanford::ErrorHandler.new(exception, @server_data)
       response = @error_handler.run
 
       # use the third proc's generated response
@@ -165,14 +165,14 @@ class Sanford::ErrorHandler
     end
 
     def second_proc
-      proc do |exception, config_data, request|
+      proc do |exception, server_data, request|
         @second_called = true
         987
       end
     end
 
     def third_proc
-      proc do |exception, config_data, request|
+      proc do |exception, server_data, request|
         @third_called = true
         876 if exception.kind_of?(Sanford::NotFoundError)
       end

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -1,0 +1,87 @@
+require 'assert'
+require 'sanford/server_data'
+
+require 'sanford/route'
+
+class Sanford::ServerData
+
+  class UnitTests < Assert::Context
+    desc "Sanford::ServerData"
+    setup do
+      @name = Factory.string
+      @ip = Factory.string
+      @port = Factory.integer
+      @pid_file = Factory.file_path
+      @logger = Factory.string
+      @verbose_logging = Factory.boolean
+      @receives_keep_alive = Factory.boolean
+      @error_procs = [ proc{ } ]
+      @route = Sanford::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
+
+      @server_data = Sanford::ServerData.new({
+        :name => @name,
+        :ip => @ip,
+        :port => @port,
+        :pid_file => @pid_file,
+        :logger => @logger,
+        :verbose_logging => @verbose_logging,
+        :receives_keep_alive => @receives_keep_alive,
+        :error_procs => @error_procs,
+        :routes => [ @route ]
+      })
+    end
+    subject{ @server_data }
+
+    should have_readers :name
+    should have_readers :ip, :port
+    should have_readers :pid_file
+    should have_readers :logger, :verbose_logging
+    should have_readers :receives_keep_alive
+    should have_readers :error_procs
+    should have_readers :routes
+
+    should "know its attributes" do
+      assert_equal @name, subject.name
+      assert_equal @ip, subject.ip
+      assert_equal @port, subject.port
+      assert_equal @pid_file, subject.pid_file
+      assert_equal @logger, subject.logger
+      assert_equal @verbose_logging, subject.verbose_logging
+      assert_equal @receives_keep_alive, subject.receives_keep_alive
+      assert_equal @error_procs, subject.error_procs
+    end
+
+    should "build a routes lookup hash" do
+      expected = { @route.name => @route }
+      assert_equal expected, subject.routes
+    end
+
+    should "allow lookup a route using `route_for`" do
+      route = subject.route_for(@route.name)
+      assert_equal @route, route
+    end
+
+    should "raise a not found error using `route_for` with an invalid name" do
+      assert_raises(Sanford::NotFoundError) do
+        subject.route_for(Factory.string)
+      end
+    end
+
+    should "default its attributes when they aren't provided" do
+      server_data = Sanford::ServerData.new
+      assert_nil server_data.name
+      assert_nil server_data.ip
+      assert_nil server_data.port
+      assert_nil server_data.pid_file
+      assert_nil server_data.logger
+      assert_false server_data.verbose_logging
+      assert_false server_data.receives_keep_alive
+      assert_equal [], server_data.error_procs
+      assert_equal({}, server_data.routes)
+    end
+
+  end
+
+  TestHandler = Class.new
+
+end


### PR DESCRIPTION
This moves the `ConfigData` out of the `Server` file and renames
it `ServerData`. This is setup for passing the `ServerData` down
to the route, runner and having its data accessible in service
handlers. Ultimately, its needed throughout Sanfords stack and it
felt wrong to require the server everywhere it was needed. This
moves it to its own file but keeps it associated with the server
by renaming it with the `server` prefix.

@kellyredding - Ready for review.
