### PR TITLE
Pass `ServerData` to route, runner and service handler

### DIFF
--- a/lib/sanford/route.rb
+++ b/lib/sanford/route.rb
@@ -16,8 +16,8 @@ module Sanford
       @handler_class = constantize_handler_class(@handler_class_name)
     end
 
-    def run(request, logger)
-      SanfordRunner.new(self.handler_class, request, logger).run
+    def run(request, server_data)
+      SanfordRunner.new(self.handler_class, request, server_data).run
     end
 
     private

--- a/lib/sanford/sanford_runner.rb
+++ b/lib/sanford/sanford_runner.rb
@@ -19,7 +19,7 @@ module Sanford
     private
 
     def run_callbacks(callbacks)
-      callbacks.each{|proc| self.handler.instance_eval(&proc) }
+      callbacks.each{ |proc| self.handler.instance_eval(&proc) }
     end
 
   end

--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -61,7 +61,8 @@ module Sanford
 
       def render(path, options = nil)
         options ||= {}
-        get_engine(path, options['source'] || Sanford.config.template_source).render(
+        options['source'] ||= @sanford_runner.template_source
+        get_engine(path, options['source']).render(
           path,
           self,
           options['locals'] || {}
@@ -70,7 +71,7 @@ module Sanford
 
       def halt(*args); @sanford_runner.halt(*args); end
       def request;     @sanford_runner.request;     end
-      def params;      self.request.params;         end
+      def params;      @sanford_runner.params;      end
       def logger;      @sanford_runner.logger;      end
 
       def run_callback(callback)

--- a/lib/sanford/test_runner.rb
+++ b/lib/sanford/test_runner.rb
@@ -1,11 +1,13 @@
 require 'sanford-protocol'
 require 'sanford/logger'
 require 'sanford/runner'
+require 'sanford/server_data'
 require 'sanford/service_handler'
+require 'sanford/template_source'
 
 module Sanford
 
-  InvalidServiceHandlerError = Class.new(RuntimeError)
+  InvalidServiceHandlerError = Class.new(StandardError)
 
   class TestRunner
     include Sanford::Runner
@@ -21,8 +23,14 @@ module Sanford
       params  = args.delete(:params)  || {}
       request = args.delete(:request) || build_request(params)
       logger  = args.delete(:logger)  || Sanford::NullLogger.new
+      template_source = args.delete(:template_source) ||
+                        Sanford::NullTemplateSource.new
 
-      super(handler_class, request, logger)
+      server_data = Sanford::ServerData.new({
+        :logger => logger,
+        :template_source => template_source
+      })
+      super(handler_class, request, server_data)
       args.each{ |key, value| @handler.send("#{key}=", value) }
 
       @response = build_response(catch(:halt){ @handler.init; nil })

--- a/test/support/service_handlers.rb
+++ b/test/support/service_handlers.rb
@@ -128,8 +128,24 @@ end
 class RenderHandler
   include Sanford::ServiceHandler
 
+  require 'sanford/template_engine'
+  class TestEngine < Sanford::TemplateEngine
+    def render(path, service_handler, locals)
+      [path.to_s, service_handler.class.to_s, locals]
+    end
+  end
+
+  def self.template_source
+    @template_source ||= begin
+      require 'sanford/template_source'
+      Sanford::TemplateSource.new(ROOT_PATH.join('test/support').to_s).tap do |s|
+        s.engine 'test', TestEngine
+      end
+    end
+  end
+
   def run!
-    render params['template_name']
+    render params['template_name'], 'source' => self.class.template_source
   end
 end
 

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'sanford/route'
 
+require 'sanford/server_data'
 require 'sanford/service_handler'
 
 class Sanford::Route
@@ -37,17 +38,16 @@ class Sanford::Route
     setup do
       @route.validate!
       @request = Factory.string
-      @logger  = Factory.string
+      @server_data = Sanford::ServerData.new
 
       @runner_spy = RunnerSpy.new(Factory.text)
       Assert.stub(Sanford::SanfordRunner, :new).with(
         @route.handler_class,
         @request,
-        @logger,
-        &proc{ @runner_spy }
-      )
+        @server_data
+      ){ @runner_spy }
 
-      @response = @route.run(@request, @logger)
+      @response = @route.run(@request, @server_data)
     end
     subject{ @response }
 

--- a/test/unit/runner_tests.rb
+++ b/test/unit/runner_tests.rb
@@ -1,31 +1,150 @@
 require 'assert'
 require 'sanford/runner'
 
-require 'test/support/service_handlers'
+require 'sanford/server_data'
+require 'sanford/service_handler'
 
 module Sanford::Runner
 
   class UnitTests < Assert::Context
     desc "Sanford::Runner"
     setup do
-      request = Sanford::Protocol::Request.new('test', {})
-      @runner_class = Class.new do
-        include Sanford::Runner
-      end
-      @runner = @runner_class.new(BasicServiceHandler, request)
+      @handler_class = TestServiceHandler
+      @request = Sanford::Protocol::Request.new(Factory.string, {
+        :something => Factory.string
+      })
+      @server_data = Sanford::ServerData.new({
+        :logger => Factory.string,
+        :template_source => Factory.string
+      })
+
+      @runner_class = TestRunner
+    end
+    subject{ @runner_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @runner = @runner_class.new(@handler_class, @request, @server_data)
     end
     subject{ @runner }
 
-    should have_readers :handler_class, :request, :logger, :handler
+    should have_readers :handler_class, :request
+    should have_readers :logger, :template_source
+    should have_readers :handler
+    should have_imeths :params
     should have_imeths :run, :run!
-    should have_imeths :halt, :catch_halt
+    should have_imeths :halt
 
-    should "not implement the run behavior" do
-      assert_raises(NotImplementedError){ subject.run }
+    should "know its handler class, request, logger and template source" do
+      assert_equal @handler_class, subject.handler_class
+      assert_equal @request, subject.request
+      assert_equal @server_data.logger, subject.logger
+      assert_equal @server_data.template_source, subject.template_source
+    end
+
+    should "build an instance of its handler class" do
+      assert_instance_of @handler_class, subject.handler
+    end
+
+    should "demeter its request params" do
+      assert_equal @request.params, subject.params
+    end
+
+    should "throw halt with response args using `halt`" do
+      code = Factory.integer
+      message = Factory.string
+      data = Factory.string
+
+      result = catch(:halt) do
+        subject.halt(code, :message => message, :data => data)
+      end
+      assert_instance_of ResponseArgs, result
+      assert_equal [ code, message ], result.status
+      assert_equal data, result.data
+    end
+
+    should "accept string keys using `halt`" do
+      code = Factory.integer
+      message = Factory.string
+      data = Factory.string
+
+      result = catch(:halt) do
+        subject.halt(code, 'message' => message, 'data' => data)
+      end
+      assert_instance_of ResponseArgs, result
+      assert_equal [ code, message ], result.status
+      assert_equal data, result.data
+    end
+
+    should "raise a not implemented error when run by default" do
+      runner_class = Class.new{ include Sanford::Runner }
+      runner = runner_class.new(@handler_class, @request, @server_data)
+      assert_raises(NotImplementedError){ runner.run }
     end
 
   end
 
-  # runner behavior tests are handled via system tests
+  class RunTests < InitTests
+    desc "and run"
+    setup do
+      @response = @runner.run
+    end
+    subject{ @response }
+
+    should "return a protocol response from the run! return-value" do
+      assert_instance_of Sanford::Protocol::Response, subject
+      assert_equal @runner.run_return_code, subject.code
+      assert_equal @runner.run_return_data, subject.data
+    end
+
+  end
+
+  class RunThatHaltsTests < UnitTests
+    desc "that halts is run"
+    setup do
+      @runner = HaltRunner.new(@handler_class, @request, @server_data)
+      @response = @runner.run
+    end
+    subject{ @response }
+
+    should "return a protocol response from the halt args" do
+      assert_instance_of Sanford::Protocol::Response, subject
+      assert_equal @runner.halt_code, subject.code
+      assert_equal @runner.halt_options[:message], subject.status.message
+      assert_equal @runner.halt_options[:data], subject.data
+    end
+
+  end
+
+  class TestRunner
+    include Sanford::Runner
+
+    attr_reader :run_return_code, :run_return_data
+
+    def run!
+      @run_return_code ||= Factory.integer
+      @run_return_data ||= Factory.string
+      [ @run_return_code, @run_return_data ]
+    end
+  end
+
+  class HaltRunner
+    include Sanford::Runner
+
+    attr_reader :halt_code, :halt_options
+
+    def run!
+      @halt_code ||= Factory.integer
+      @halt_options ||= { :message => Factory.string, :data => Factory.string }
+      halt(@halt_code, @halt_options)
+    end
+  end
+
+  class TestServiceHandler
+    include Sanford::ServiceHandler
+  end
 
 end

--- a/test/unit/sanford_runner_tests.rb
+++ b/test/unit/sanford_runner_tests.rb
@@ -1,19 +1,22 @@
 require 'assert'
 require 'sanford/sanford_runner'
 
-require 'sanford/runner'
-require 'test/support/service_handlers'
+require 'sanford/server_data'
 
 class Sanford::SanfordRunner
 
   class UnitTests < Assert::Context
     desc "Sanford::SanfordRunner"
     setup do
+      @handler_class = TestServiceHandler
+      @request = Sanford::Protocol::Request.new(Factory.string, {})
+      @server_data = Sanford::ServerData.new
+
       @runner_class = Sanford::SanfordRunner
     end
     subject{ @runner_class }
 
-    should "be a Runner" do
+    should "be a runner" do
       assert_includes Sanford::Runner, subject
     end
 
@@ -22,36 +25,65 @@ class Sanford::SanfordRunner
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @request = Sanford::Protocol::Request.new('test', {})
-      @runner = @runner_class.new(BasicServiceHandler, @request)
+      @runner = @runner_class.new(@handler_class, @request, @server_data)
     end
     subject{ @runner }
 
-    should "run the handler and return the response it generates when run" do
-      response = subject.run
-
-      assert_instance_of Sanford::Protocol::Response, response
-      assert_equal 200, response.code
-      assert_equal 'Joe Test', response.data['name']
-      assert_equal 'joe.test@example.com',  response.data['email']
-    end
-
   end
 
-  class CallbackTests < InitTests
+  class RunTests < InitTests
+    desc "and run"
     setup do
-      @runner = @runner_class.new(FlagServiceHandler, @request)
+      @handler = @runner.handler
+      @response = @runner.run
+    end
+    subject{ @response }
+
+    should "run the handlers before callbacks" do
+      assert_equal 1, @handler.before_call_order
     end
 
-    should "call handler `before` and `after` callbacks when run" do
-      subject.run
+    should "run the handlers init" do
+      assert_equal 2, @handler.init_call_order
+    end
 
-      assert_true subject.handler.before_called
-      assert_true subject.handler.after_called
+    should "run the handlers run and use its result to build a response" do
+      assert_equal 3, @handler.run_call_order
+      assert_instance_of Sanford::Protocol::Response, subject
+      assert_equal @handler.response_data, subject.data
+    end
+
+    should "run the handlers after callbacks" do
+      assert_equal 4, @handler.after_call_order
     end
 
   end
 
-  # live runner behavior tests are handled via system tests
+  class TestServiceHandler
+    include Sanford::ServiceHandler
+
+    attr_reader :before_call_order, :after_call_order
+    attr_reader :init_call_order, :run_call_order
+    attr_reader :response_data
+
+    before{ @before_call_order = next_call_order }
+    after{ @after_call_order = next_call_order }
+
+    def init!
+      @init_call_order = next_call_order
+    end
+
+    def run!
+      @run_call_order = next_call_order
+      @response_data ||= Factory.string
+    end
+
+    private
+
+    def next_call_order
+      @order ||= 0
+      @order += 1
+    end
+  end
 
 end

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -7,11 +7,12 @@ class Sanford::TestRunner
     desc "Sanford::TestRunner"
     setup do
       @handler_class = TestServiceHandler
-      @logger = Factory.string
-      @params = { :something => Factory.string }
       @request = Sanford::Protocol::Request.new(Factory.string, {
         :other => Factory.string
       })
+      @params = { :something => Factory.string }
+      @logger = Factory.string
+      @template_source = Factory.string
       @handler_flag = Factory.boolean
 
       @runner_class = Sanford::TestRunner
@@ -28,8 +29,9 @@ class Sanford::TestRunner
     desc "when init"
     setup do
       @runner = @runner_class.new(@handler_class, {
-        :logger => @logger,
         :params => @params,
+        :logger => @logger,
+        :template_source => @template_source,
         :flag => @handler_flag
       })
     end
@@ -38,8 +40,9 @@ class Sanford::TestRunner
     should have_readers :response
     should have_imeths :run, :run!
 
-    should "know its logger" do
+    should "know its logger and template source" do
       assert_equal @logger, subject.logger
+      assert_equal @template_source, subject.template_source
     end
 
     should "build a request using the params" do
@@ -59,11 +62,12 @@ class Sanford::TestRunner
       assert_equal @request, test_runner.request
     end
 
-    should "default its logger, params and request" do
+    should "default its logger, params, request and template source" do
       test_runner = @runner_class.new(@handler_class)
       assert_instance_of Sanford::NullLogger, test_runner.logger
       expected = Sanford::Protocol::Request.new('name', {})
       assert_equal expected, test_runner.request
+      assert_instance_of Sanford::NullTemplateSource, test_runner.template_source
     end
 
     should "have called init on its service handler" do


### PR DESCRIPTION
This adds passing a server's `ServerData` to a route when running
it. The route then uses the `ServerData` to build a runner. This
changes `Runner` to require a server data and forces the
`TestRunner` to build one and `super` it to conform to this. This
makes the `ServerData` available to the runners and also service
handlers, which allows removing usage of `Sanford.config`.

Previously, runners used `Sanford.config` to default their logger
and service handlers used it to default their template source.
Since `Sanford.config` is going away, they needed to get this
data through their server's configuration.

This also makes a small change to runners to demeter their
request params. This is called by the service handlers `params`
method instead of it calling the request and then calling `params`
on that.

Finally, this adds more complete unit tests for `Runner` and
`SanfordRunner`.

@kellyredding - Ready for review.
