### PR TITLE
Add server system test for a service that renders a template

### DIFF
--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -260,7 +260,8 @@ module Sanford
       def to_hash
         super.merge({
           :error_procs => self.error_procs,
-          :routes => self.routes
+          :routes => self.routes,
+          :template_source => self.template_source
         })
       end
 

--- a/test/support/template.erb
+++ b/test/support/template.erb
@@ -1,0 +1,1 @@
+ERB Template Message: <%= view.message %>

--- a/test/system/server_tests.rb
+++ b/test/system/server_tests.rb
@@ -45,7 +45,7 @@ module Sanford::Server
       @response = @client.call
     end
 
-    should "return a response" do
+    should "return a success response" do
       assert_equal 200, subject.code
       assert_nil subject.status.message
       assert_equal @message, subject.data
@@ -155,6 +155,22 @@ module Sanford::Server
       assert_equal 500, subject.code
       assert_equal "An unexpected error occurred.", subject.status.message
       assert_nil subject.data
+    end
+
+  end
+
+  class TemplateTests < SystemTests
+    desc "calling a service that renders a template"
+    setup do
+      @message = Factory.text
+      @client.set_request('template', :message => @message)
+      @response = @client.call
+    end
+
+    should "return a success response with the rendered data" do
+      assert_equal 200, subject.code
+      assert_nil subject.status.message
+      assert_equal "ERB Template Message: #{@message}\n", subject.data
     end
 
   end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -444,10 +444,11 @@ module Sanford::Server
       assert_equal subject.router.routes, subject.routes
     end
 
-    should "include its routes and error procs in its hash" do
+    should "include its routes, error procs and template source in its hash" do
       config_hash = subject.to_hash
       assert_equal subject.error_procs, config_hash[:error_procs]
       assert_equal subject.routes, config_hash[:routes]
+      assert_equal subject.template_source, config_hash[:template_source]
     end
 
     should "call its init procs when validated" do


### PR DESCRIPTION
This adds a system test for a service that renders a template.
The goal of this test is to ensure that a template source
configured on the server can be used to render a template for
a service handler. This also fixes a bug where the configuration
was not passing the template source to server data. This fixes
that and ensures that configuring a template source and using it
to render a template works as expected.

@kellyredding - Ready for review. Test did what it was supposed to, let me know there was a bug with getting the template source to the service handler.
