### PR TITLE
Simplify `Sanford::Runner`

### DIFF
--- a/bench/report.txt
+++ b/bench/report.txt
@@ -2,38 +2,34 @@ Running benchmark report...
 
 Hitting "simple" service with {}, 10000 times
 ....................................................................................................
-Total Time:   5164.9393ms
-Average Time:    0.5164ms
-Min Time:        0.3499ms
-Max Time:       33.7579ms
+Total Time:   5242.6066ms
+Average Time:    0.5242ms
+Min Time:        0.3550ms
+Max Time:       34.3449ms
 
 Distribution (number of requests):
-  0ms: 9937
-    0.3ms: 5996
-    0.4ms: 3544
-    0.5ms: 247
-    0.6ms: 89
-    0.7ms: 34
+  0ms: 9944
+    0.3ms: 4361
+    0.4ms: 5151
+    0.5ms: 268
+    0.6ms: 112
+    0.7ms: 32
     0.8ms: 13
-    0.9ms: 14
-  1ms: 24
+    0.9ms: 7
+  1ms: 18
     1.0ms: 5
-    1.1ms: 7
+    1.1ms: 2
     1.2ms: 7
-    1.3ms: 2
+    1.3ms: 3
     1.4ms: 1
-    1.5ms: 1
-    1.6ms: 1
-  3ms: 1
-  11ms: 1
-  13ms: 1
+  2ms: 2
+  7ms: 1
   16ms: 1
-  23ms: 1
-  28ms: 5
-  29ms: 15
-  30ms: 2
-  31ms: 4
-  32ms: 6
-  33ms: 2
+  29ms: 14
+  30ms: 8
+  31ms: 1
+  32ms: 3
+  33ms: 7
+  34ms: 1
 
 Done running benchmark report

--- a/lib/sanford/runner.rb
+++ b/lib/sanford/runner.rb
@@ -1,67 +1,47 @@
-require 'ostruct'
 require 'sanford-protocol'
 require 'sanford/logger'
 require 'sanford/template_source'
 
 module Sanford
 
-  module Runner
+  class Runner
 
     ResponseArgs = Struct.new(:status, :data)
 
-    def self.included(klass)
-      klass.class_eval do
-        include InstanceMethods
-      end
+    attr_reader :handler_class, :handler
+    attr_reader :request, :params, :logger, :template_source
+
+    def initialize(handler_class)
+      @handler_class = handler_class
+      @handler = @handler_class.new(self)
     end
 
-    module InstanceMethods
+    def run
+      raise NotImplementedError
+    end
 
-      attr_reader :handler_class, :request
-      attr_reader :logger, :template_source
-      attr_reader :handler
+    # It's best to keep what `halt` and `catch_halt` return in the same format.
+    # Currently this is a `ResponseArgs` object. This is so no matter how the
+    # block returns (either by throwing or running normally), you get the same
+    # thing kind of object.
 
-      def initialize(handler_class, request, server_data)
-        @handler_class = handler_class
-        @request = request
-        @logger = server_data.logger || Sanford::NullLogger.new
-        @template_source = server_data.template_source || Sanford::NullTemplateSource.new
-        @handler = @handler_class.new(self)
-      end
+    def halt(status, options = nil)
+      options ||= {}
+      message = options[:message] || options['message']
+      response_status = [ status, message ]
+      response_data = options[:data] || options['data']
+      throw :halt, ResponseArgs.new(response_status, response_data)
+    end
 
-      def params
-        @request.params
-      end
+    private
 
-      def run
-        build_response catch_halt{ self.run! }
-      end
+    def catch_halt(&block)
+      catch(:halt){ ResponseArgs.new(*block.call) }
+    end
 
-      def run!
-        raise NotImplementedError
-      end
-
-      # It's best to keep what `halt` and `catch_halt` return in the same format.
-      # Currently this is a `ResponseArgs` object. This is so no matter how the
-      # block returns (either by throwing or running normally), you get the same
-      # thing kind of object.
-
-      def halt(status, options = nil)
-        options = OpenStruct.new(options || {})
-        response_status = [ status, options.message ]
-        throw :halt, ResponseArgs.new(response_status, options.data)
-      end
-
-      private
-
-      def catch_halt(&block)
-        catch(:halt){ ResponseArgs.new(*block.call) }
-      end
-
-      def build_response(args)
-        Sanford::Protocol::Response.new(args.status, args.data) if args
-      end
-
+    def build_response(&block)
+      args = catch_halt(&block)
+      Sanford::Protocol::Response.new(args.status, args.data)
     end
 
   end

--- a/lib/sanford/sanford_runner.rb
+++ b/lib/sanford/sanford_runner.rb
@@ -2,18 +2,28 @@ require 'sanford/runner'
 
 module Sanford
 
-  class SanfordRunner
-    include Sanford::Runner
+  class SanfordRunner < Sanford::Runner
+
+    def initialize(handler_class, request, server_data)
+      @request         = request
+      @params          = @request.params
+      @logger          = server_data.logger
+      @template_source = server_data.template_source
+
+      super(handler_class)
+    end
 
     # call the handler init and the handler run - if the init halts, run won't
     # be called.
 
-    def run!
-      run_callbacks self.handler_class.before_callbacks
-      self.handler.init
-      response_args = self.handler.run
-      run_callbacks self.handler_class.after_callbacks
-      response_args
+    def run
+      build_response do
+        run_callbacks self.handler_class.before_callbacks
+        self.handler.init
+        return_value = self.handler.run
+        run_callbacks self.handler_class.after_callbacks
+        return_value
+      end
     end
 
     private

--- a/test/unit/sanford_runner_tests.rb
+++ b/test/unit/sanford_runner_tests.rb
@@ -10,15 +10,20 @@ class Sanford::SanfordRunner
     desc "Sanford::SanfordRunner"
     setup do
       @handler_class = TestServiceHandler
-      @request = Sanford::Protocol::Request.new(Factory.string, {})
-      @server_data = Sanford::ServerData.new
+      @request = Sanford::Protocol::Request.new(Factory.string, {
+        :something => Factory.string
+      })
+      @server_data = Sanford::ServerData.new({
+        :logger => Factory.string,
+        :template_source => Factory.string
+      })
 
       @runner_class = Sanford::SanfordRunner
     end
     subject{ @runner_class }
 
     should "be a runner" do
-      assert_includes Sanford::Runner, subject
+      assert_true subject < Sanford::Runner
     end
 
   end
@@ -29,6 +34,13 @@ class Sanford::SanfordRunner
       @runner = @runner_class.new(@handler_class, @request, @server_data)
     end
     subject{ @runner }
+
+    should "know its request, params, logger and template source" do
+      assert_equal @request, subject.request
+      assert_equal @request.params, subject.params
+      assert_equal @server_data.logger, subject.logger
+      assert_equal @server_data.template_source, subject.template_source
+    end
 
   end
 
@@ -41,21 +53,103 @@ class Sanford::SanfordRunner
     subject{ @response }
 
     should "run the handlers before callbacks" do
-      assert_equal 1, @handler.before_call_order
+      assert_equal 1, @handler.first_before_call_order
+      assert_equal 2, @handler.second_before_call_order
     end
 
     should "run the handlers init" do
-      assert_equal 2, @handler.init_call_order
+      assert_equal 3, @handler.init_call_order
     end
 
     should "run the handlers run and use its result to build a response" do
-      assert_equal 3, @handler.run_call_order
+      assert_equal 4, @handler.run_call_order
       assert_instance_of Sanford::Protocol::Response, subject
       assert_equal @handler.response_data, subject.data
     end
 
     should "run the handlers after callbacks" do
-      assert_equal 4, @handler.after_call_order
+      assert_equal 5, @handler.first_after_call_order
+      assert_equal 6, @handler.second_after_call_order
+    end
+
+  end
+
+  class RunHaltInBeforeTests < UnitTests
+    desc "running a handler that halts in a before callback"
+    setup do
+      req = Sanford::Protocol::Request.new(Factory.string, 'halt' => 'before')
+      runner = @runner_class.new(@handler_class, req, @server_data).tap(&:run)
+      @handler = runner.handler
+    end
+    subject{ @handler }
+
+    should "stop processing when the halt is called" do
+      assert_not_nil subject.first_before_call_order
+      assert_nil subject.second_before_call_order
+      assert_nil subject.init_call_order
+      assert_nil subject.run_call_order
+      assert_nil subject.first_after_call_order
+      assert_nil subject.second_after_call_order
+    end
+
+  end
+
+  class RunHandlerHaltInitTests < UnitTests
+    desc "running a handler that halts in init"
+    setup do
+      req = Sanford::Protocol::Request.new(Factory.string, 'halt' => 'init')
+      runner = @runner_class.new(@handler_class, req, @server_data).tap(&:run)
+      @handler = runner.handler
+    end
+    subject{ @handler }
+
+    should "stop processing when the halt is called" do
+      assert_not_nil subject.first_before_call_order
+      assert_not_nil subject.second_before_call_order
+      assert_not_nil subject.init_call_order
+      assert_nil subject.run_call_order
+      assert_nil subject.first_after_call_order
+      assert_nil subject.second_after_call_order
+    end
+
+  end
+
+  class RunHandlerHaltRunTests < UnitTests
+    desc "running a handler that halts in run"
+    setup do
+      req = Sanford::Protocol::Request.new(Factory.string, 'halt' => 'run')
+      runner = @runner_class.new(@handler_class, req, @server_data).tap(&:run)
+      @handler = runner.handler
+    end
+    subject{ @handler }
+
+    should "stop processing when the halt is called" do
+      assert_not_nil subject.first_before_call_order
+      assert_not_nil subject.second_before_call_order
+      assert_not_nil subject.init_call_order
+      assert_not_nil subject.run_call_order
+      assert_nil subject.first_after_call_order
+      assert_nil subject.second_after_call_order
+    end
+
+  end
+
+  class RunHandlerHaltAfterTests < UnitTests
+    desc "running a handler that halts in a after callback"
+    setup do
+      req = Sanford::Protocol::Request.new(Factory.string, 'halt' => 'after')
+      runner = @runner_class.new(@handler_class, req, @server_data).tap(&:run)
+      @handler = runner.handler
+    end
+    subject{ @handler }
+
+    should "stop processing when the halt is called" do
+      assert_not_nil subject.first_before_call_order
+      assert_not_nil subject.second_before_call_order
+      assert_not_nil subject.init_call_order
+      assert_not_nil subject.run_call_order
+      assert_not_nil subject.first_after_call_order
+      assert_nil subject.second_after_call_order
     end
 
   end
@@ -63,19 +157,31 @@ class Sanford::SanfordRunner
   class TestServiceHandler
     include Sanford::ServiceHandler
 
-    attr_reader :before_call_order, :after_call_order
+    attr_reader :first_before_call_order, :second_before_call_order
+    attr_reader :first_after_call_order, :second_after_call_order
     attr_reader :init_call_order, :run_call_order
     attr_reader :response_data
 
-    before{ @before_call_order = next_call_order }
-    after{ @after_call_order = next_call_order }
+    before do
+      @first_before_call_order = next_call_order
+      halt_if('before')
+    end
+    before{ @second_before_call_order = next_call_order }
+
+    after do
+      @first_after_call_order = next_call_order
+      halt_if('after')
+    end
+    after{ @second_after_call_order = next_call_order }
 
     def init!
       @init_call_order = next_call_order
+      halt_if('init')
     end
 
     def run!
       @run_call_order = next_call_order
+      halt_if('run')
       @response_data ||= Factory.string
     end
 
@@ -84,6 +190,10 @@ class Sanford::SanfordRunner
     def next_call_order
       @order ||= 0
       @order += 1
+    end
+
+    def halt_if(value)
+      halt Factory.integer if params['halt'] == value
     end
   end
 


### PR DESCRIPTION
This is a set of changes that simplify `Runner` and decouple
the `SanfordRunner` and the `TestRunner`. Previously, the
`TestRunner` had to jump through hoops to work with `Runner`. This
was because `Runner` was providing logic that only `SanfordRunner`
needed. This was originally done because `Runner` use to be a
mixin that was could be used to define a custom runner and
configure it with a Sanford server. This is no longer the case and
`Runner` is now a class.

`Runner` has been simplified by not deciding how its attributes
are set. It only requires a handler class and it will build the
handler. The `TestRunner` is now free to expect its attributes are
optionally passed to it. It also doesn't have to worry about being
provided or building a server data. These changes move `Runner`
logic to the `SanfordRunner` which allows it to continue to require
a request and server data are passed to it. The `SanfordRunner`
can also be more strict and not worry about defaulting attributes.

With the moving of logic into the `SanfordRunner`, it's tests have
been beefed up to ensure it is providing the behavior it should. In
addition to this, this ensures that it runs multiple before and
after callbacks in the correct order.

All of this allows the `TestRunner` and `SanfordRunner` to work as
needed without extra hoops to jump through but still allow them
to provide the desired interfaces for their contexts.

@kellyredding - Ready for review. This follows the Deas pattern as much as possible. The big differences between this and Deas is that the common `Runner` provides the `halt` behavior and response building logic. This is because in both live and test scenarios we want to build responses where as in Deas in a test environment, we just return the response or halt args as needed.
