### PR TITLE
Rename `Worker` to `ConnectionHandler`

### DIFF
--- a/lib/sanford/connection_handler.rb
+++ b/lib/sanford/connection_handler.rb
@@ -6,7 +6,7 @@ require 'sanford/runner'
 
 module Sanford
 
-  class Worker
+  class ConnectionHandler
 
     ProcessedService = Struct.new(
       :request, :handler_class, :response, :exception, :time_taken

--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -7,7 +7,7 @@ require 'sanford/logger'
 require 'sanford/router'
 require 'sanford/server_data'
 require 'sanford/template_source'
-require 'sanford/worker'
+require 'sanford/connection_handler'
 
 module Sanford
 
@@ -93,7 +93,7 @@ module Sanford
       def serve(socket)
         connection = Connection.new(socket)
         if !keep_alive_connection?(connection)
-          Sanford::Worker.new(@server_data, connection).run
+          Sanford::ConnectionHandler.new(@server_data, connection).run
         end
       end
 

--- a/test/unit/connection_handler_tests.rb
+++ b/test/unit/connection_handler_tests.rb
@@ -1,14 +1,14 @@
 require 'assert'
-require 'sanford/worker'
+require 'sanford/connection_handler'
 
 require 'sanford/route'
 require 'sanford/server_data'
 require 'test/support/fake_server_connection'
 
-class Sanford::Worker
+class Sanford::ConnectionHandler
 
   class UnitTests < Assert::Context
-    desc "Sanford::Worker"
+    desc "Sanford::ConnectionHandler"
     setup do
       @route = Sanford::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
       @server_data = Sanford::ServerData.new({
@@ -21,18 +21,18 @@ class Sanford::Worker
       @response = Sanford::Protocol::Response.new(Factory.integer, Factory.string)
       @exception = RuntimeError.new(Factory.string)
 
-      @worker_class = Sanford::Worker
+      @handler_class = Sanford::ConnectionHandler
     end
-    subject{ @worker_class }
+    subject{ @handler_class }
 
   end
 
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @worker = @worker_class.new(@server_data, @connection)
+      @connection_handler = @handler_class.new(@server_data, @connection)
     end
-    subject{ @worker }
+    subject{ @connection_handler }
 
     should have_readers :server_data, :connection
     should have_readers :logger
@@ -58,7 +58,7 @@ class Sanford::Worker
         @response
       end
 
-      @processed_service = @worker.run
+      @processed_service = @connection_handler.run
     end
     subject{ @processed_service }
 
@@ -97,7 +97,7 @@ class Sanford::Worker
       @expected_response = error_handler.run
       @expected_exception = error_handler.exception
 
-      @processed_service = @worker.run
+      @processed_service = @connection_handler.run
     end
     subject{ @processed_service }
 
@@ -129,7 +129,7 @@ class Sanford::Worker
       @expected_response = error_handler.run
       @expected_exception = error_handler.exception
 
-      @processed_service = @worker.run
+      @processed_service = @connection_handler.run
     end
     subject{ @processed_service }
 
@@ -157,7 +157,7 @@ class Sanford::Worker
     end
 
     should "raise the exception" do
-      assert_raises(@exception.class){ @worker.run }
+      assert_raises(@exception.class){ @connection_handler.run }
     end
 
   end
@@ -173,8 +173,8 @@ class Sanford::Worker
       })
       Assert.stub(@route, :run){ raise @exception }
 
-      @worker = @worker_class.new(@server_data, @connection)
-      @processed_service = @worker.run
+      @connection_handler = @handler_class.new(@server_data, @connection)
+      @processed_service = @connection_handler.run
     end
     subject{ @spy_logger }
 
@@ -209,8 +209,8 @@ class Sanford::Worker
       })
       Assert.stub(@route, :run){ raise @exception }
 
-      @worker = @worker_class.new(@server_data, @connection)
-      @processed_service = @worker.run
+      @connection_handler = @handler_class.new(@server_data, @connection)
+      @processed_service = @connection_handler.run
     end
     subject{ @spy_logger }
 

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -282,37 +282,37 @@ module Sanford::Server
       @connection = FakeServerConnection.new
       Assert.stub(Connection, :new).with(@socket){ @connection }
 
-      @worker_spy = WorkerSpy.new
-      Assert.stub(Sanford::Worker, :new).tap do |s|
-        s.with(@server.server_data, @connection){ @worker_spy }
+      @connection_handler_spy = ConnectionHandlerSpy.new
+      Assert.stub(Sanford::ConnectionHandler, :new).tap do |s|
+        s.with(@server.server_data, @connection){ @connection_handler_spy }
       end
 
       @serve_proc = @dat_tcp_server_spy.serve_proc
     end
     subject{ @serve_proc }
 
-    should "run a worker when called with a socket" do
+    should "run a connection_handler when called with a socket" do
       Assert.stub(@server.server_data, :receives_keep_alive){ false }
       @connection.read_data = Factory.boolean
-      assert_false @worker_spy.run_called
+      assert_false @connection_handler_spy.run_called
       subject.call(@socket)
-      assert_true @worker_spy.run_called
+      assert_true @connection_handler_spy.run_called
     end
 
     should "not run a keep-alive connection when configured to receive them" do
       Assert.stub(@server.server_data, :receives_keep_alive){ true }
       @connection.read_data = nil # nothing to read makes it a keep-alive
-      assert_false @worker_spy.run_called
+      assert_false @connection_handler_spy.run_called
       subject.call(@socket)
-      assert_false @worker_spy.run_called
+      assert_false @connection_handler_spy.run_called
     end
 
     should "run a keep-alive connection when configured to receive them" do
       Assert.stub(@server.server_data, :receives_keep_alive){ false }
       @connection.read_data = nil # nothing to read makes it a keep-alive
-      assert_false @worker_spy.run_called
+      assert_false @connection_handler_spy.run_called
       subject.call(@socket)
-      assert_true @worker_spy.run_called
+      assert_true @connection_handler_spy.run_called
     end
 
   end
@@ -512,7 +512,7 @@ module Sanford::Server
     end
   end
 
-  class WorkerSpy
+  class ConnectionHandlerSpy
     attr_reader :run_called
 
     def initialize


### PR DESCRIPTION
This renames the `Worker` to `ConnectionHandler`. Worker was a
poor name for this piece of logic and comes from assuming the
internals of DatTCP. This renames it to more accurately describe
what it does, handles a new connection. This means parsing a
request, running its route and writing the response. This doesn't
change any functionality, its just a rename.

@kellyredding - Ready for review.
