### PR TITLE
Add `render` to `TemplateSource`, decouple from `ServiceHandler`

### DIFF
--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -5,8 +5,6 @@ module Sanford
 
   module ServiceHandler
 
-    DISALLOWED_TEMPLATE_EXTS = Sanford::TemplateSource::DISALLOWED_ENGINE_EXTS
-
     def self.included(klass)
       klass.class_eval do
         extend ClassMethods
@@ -51,12 +49,8 @@ module Sanford
 
       def render(path, options = nil)
         options ||= {}
-        options['source'] ||= @sanford_runner.template_source
-        get_engine(path, options['source']).render(
-          path,
-          self,
-          options['locals'] || {}
-        )
+        source = options['source'] || @sanford_runner.template_source
+        source.render(path, self, options['locals'] || {})
       end
 
       def halt(*args); @sanford_runner.halt(*args); end
@@ -68,18 +62,6 @@ module Sanford
         (self.class.send("#{callback}_callbacks") || []).each do |callback|
           self.instance_eval(&callback)
         end
-      end
-
-      private
-
-      def get_engine(path, source)
-        source.engines[File.extname(get_template(path, source))[1..-1] || '']
-      end
-
-      def get_template(path, source)
-        files = Dir.glob("#{Pathname.new(source.path).join(path.to_s)}.*")
-        files = files.reject{ |p| DISALLOWED_TEMPLATE_EXTS.include?(File.extname(p)) }
-        files.first.to_s
       end
 
     end

--- a/lib/sanford/template_source.rb
+++ b/lib/sanford/template_source.rb
@@ -4,7 +4,7 @@ module Sanford
 
   class TemplateSource
 
-    DISALLOWED_ENGINE_EXTS = [ '.rb' ]
+    DISALLOWED_ENGINE_EXTS = [ 'rb' ]
 
     DisallowedEngineExtError = Class.new(ArgumentError)
 
@@ -17,12 +17,29 @@ module Sanford
     end
 
     def engine(input_ext, engine_class, registered_opts = nil)
-      if DISALLOWED_ENGINE_EXTS.include?(".#{input_ext}")
+      if DISALLOWED_ENGINE_EXTS.include?(input_ext)
         raise DisallowedEngineExtError, "`#{input_ext}` is disallowed as an"\
                                         " engine extension."
       end
       engine_opts = @default_opts.merge(registered_opts || {})
       @engines[input_ext.to_s] = engine_class.new(engine_opts)
+    end
+
+    def render(template_path, service_handler, locals)
+      engine = @engines[get_template_ext(template_path)]
+      engine.render(template_path, service_handler, locals)
+    end
+
+    private
+
+    def get_template_ext(template_path)
+      files = Dir.glob("#{File.join(@path, template_path.to_s)}.*")
+      files = files.reject{ |p| !@engines.keys.include?(parse_ext(p)) }
+      parse_ext(files.first.to_s || '')
+    end
+
+    def parse_ext(template_path)
+      File.extname(template_path)[1..-1]
     end
 
   end

--- a/test/unit/service_handler_tests.rb
+++ b/test/unit/service_handler_tests.rb
@@ -27,11 +27,6 @@ module Sanford::ServiceHandler
     should have_imeths :prepend_before_init, :prepend_after_init
     should have_imeths :prepend_before_run,  :prepend_after_run
 
-    should "disallow certain template extensions" do
-      exp = Sanford::TemplateSource::DISALLOWED_ENGINE_EXTS
-      assert_equal exp, subject::DISALLOWED_TEMPLATE_EXTS
-    end
-
     should "return an empty array by default using `before_callbacks`" do
       assert_equal [], subject.before_callbacks
     end

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -10,7 +10,7 @@ class Sanford::TemplateSource
     subject{ Sanford::TemplateSource }
 
     should "disallow certain engine extensions" do
-      exp = [ '.rb' ]
+      exp = [ 'rb' ]
       assert_equal exp, subject::DISALLOWED_ENGINE_EXTS
     end
 
@@ -24,7 +24,7 @@ class Sanford::TemplateSource
     subject{ @source }
 
     should have_readers :path, :engines
-    should have_imeths :engine
+    should have_imeths :engine, :render
 
     should "know its path" do
       assert_equal @source_path.to_s, subject.path
@@ -35,40 +35,66 @@ class Sanford::TemplateSource
   class EngineRegistrationTests < InitTests
     desc "when registering an engine"
     setup do
-      @empty_engine = Class.new(Sanford::TemplateEngine) do
-        def render(path, scope); ''; end
-      end
+      @test_engine = TestEngine
     end
 
     should "allow registering new engines" do
-      assert_kind_of Sanford::NullTemplateEngine, subject.engines['empty']
-      subject.engine 'empty', @empty_engine
-      assert_kind_of @empty_engine, subject.engines['empty']
+      assert_kind_of Sanford::NullTemplateEngine, subject.engines['test']
+      subject.engine 'test', @test_engine
+      assert_kind_of @test_engine, subject.engines['test']
     end
 
     should "register with the source path as a default option" do
-      subject.engine 'empty', @empty_engine
+      subject.engine 'test', @test_engine
       exp_opts = { 'source_path' => subject.path }
-      assert_equal exp_opts, subject.engines['empty'].opts
+      assert_equal exp_opts, subject.engines['test'].opts
 
-      subject.engine 'empty', @empty_engine, 'an' => 'opt'
+      subject.engine 'test', @test_engine, 'an' => 'opt'
       exp_opts = {
         'source_path' => subject.path,
         'an' => 'opt'
       }
-      assert_equal exp_opts, subject.engines['empty'].opts
+      assert_equal exp_opts, subject.engines['test'].opts
 
-      subject.engine 'empty', @empty_engine, 'source_path' => 'something'
+      subject.engine 'test', @test_engine, 'source_path' => 'something'
       exp_opts = { 'source_path' => 'something' }
-      assert_equal exp_opts, subject.engines['empty'].opts
+      assert_equal exp_opts, subject.engines['test'].opts
     end
 
     should "complain if registering a disallowed temp" do
       assert_kind_of Sanford::NullTemplateEngine, subject.engines['rb']
       assert_raises DisallowedEngineExtError do
-        subject.engine 'rb', @empty_engine
+        subject.engine 'rb', @test_engine
       end
       assert_kind_of Sanford::NullTemplateEngine, subject.engines['rb']
+    end
+
+  end
+
+  class RenderTests < InitTests
+    desc "when rendering a template"
+    setup do
+      @source.engine('test', TestEngine)
+      @source.engine('json', JsonEngine)
+    end
+
+    should "render a matching template using the configured engine" do
+      locals = { :something => Factory.string }
+      result = subject.render('test_template', TestServiceHandler, locals)
+      assert_equal 'test-engine', result
+    end
+
+    should "only try rendering template files its has engines for" do
+      # there should be 2 files called "template" in `test/support` with diff
+      # extensions
+      result = subject.render('template', TestServiceHandler, {})
+      assert_equal 'json-engine', result
+    end
+
+    should "use the null template engine when an engine can't be found" do
+      assert_raises(ArgumentError) do
+        subject.render(Factory.string, TestServiceHandler, {})
+      end
     end
 
   end
@@ -89,5 +115,19 @@ class Sanford::TemplateSource
     end
 
   end
+
+  class TestEngine < Sanford::TemplateEngine
+    def render(path, service_handler, locals)
+      'test-engine'
+    end
+  end
+
+  class JsonEngine < Sanford::TemplateEngine
+    def render(path, service_handler, locals)
+      'json-engine'
+    end
+  end
+
+  TestServiceHandler = Class.new
 
 end


### PR DESCRIPTION
This adjusts the template rendering behavior to decouple service
handlers and a template source. `TemplateSource` now provides a
`render` method which is all the service handler needs to call to
render a template. The `TemplateSource` takes care of finding the
templates and finding a matching configured engine and calling
`render` on it. This keeps service handlers from having to know
how to lookup engines and centralizes all the file extension
handling.

This also tweaks the template lookup slightly. Sources will now
reject templates for which they do not have a configured engine
for. This covers ensuring we do not select a `.rb` template
(since we don't allow engines to be configured for this extension)
and avoids a really minor issue with trying to render a template
when there are two or more files with the same name but different
extensions. If you try to render "template" and you have a
"template.erb" and a "template.json" file in your source path,
then the previous logic would always choose the erb file. If the
source was configured to work with json but not erb you can't
render your json template. Only selecting templates that are
configured helps to pick the correct template in this rare
situation.

@kellyredding - Ready for review. Ran into this while working on the unit tests for the service handler. I was trying to test its `render` method and I was having to do all the setup of creating a source and an engine and make sure everything lined up. I also ran into the issue of it not rendering my `template.json` because it would always choose `template.erb`. I started adding the logic to the service handler and thought it shouldn't have to know so much about the template source structure. 
