### PR TITLE
server config: update `to_hash` to include `init_procs`

### DIFF
--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -266,9 +266,9 @@ module Sanford
 
       def to_hash
         super.merge({
+          :init_procs => self.init_procs,
           :error_procs => self.error_procs,
-          :routes => self.routes,
-          :template_source => self.template_source
+          :routes => self.routes
         })
       end
 

--- a/sanford.gemspec
+++ b/sanford.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("dat-tcp",          ["~> 0.5"])
   gem.add_dependency("ns-options",       ["~> 1.1"])
-  gem.add_dependency("sanford-protocol", ["~> 0.9"])
+  gem.add_dependency("sanford-protocol", ["~> 0.10"])
 
-  gem.add_development_dependency("assert", ["~> 2.11"])
+  gem.add_development_dependency("assert", ["~> 2.12"])
 end

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -448,13 +448,11 @@ module Sanford::Server
       assert_equal subject.router.routes, subject.routes
     end
 
-    should "include its routes, error procs and template source in its hash" do
+    should "include its init/error procs and routes in its hash representation" do
       config_hash = subject.to_hash
+      assert_equal subject.init_procs, config_hash[:init_procs]
       assert_equal subject.error_procs, config_hash[:error_procs]
       assert_equal subject.routes, config_hash[:routes]
-      template_source = subject.template_source
-      assert_instance_of template_source.class, config_hash[:template_source]
-      assert_equal template_source.path, config_hash[:template_source].path
     end
 
     should "call its init procs when validated" do


### PR DESCRIPTION
This is a minor cleanup to the server configuration `to_hash`
representation.  This removes `template_source` as it is included
by being a ns option.  This also adds init procs as this is more
proper since we are already adding error procs.  Now the custom
to hash method just adds in non-option atts values.

This also updates a few version dependencies to get on the latest
stuff.

Overall, no behavior changes.  Nothing is currently relying on
init procs being in the hash and template_source is still in it b/c
it is an option.

@jcredding ready for review.
