### PR TITLE
Make `CLI` behavior and output to match latest conventions

### DIFF
--- a/lib/sanford/cli.rb
+++ b/lib/sanford/cli.rb
@@ -23,7 +23,7 @@ module Sanford
       rescue CLIRB::HelpExit
         @kernel.puts help
       rescue CLIRB::VersionExit
-        @kernel.puts "sanford #{Sanford::VERSION}"
+        @kernel.puts Sanford::VERSION
       rescue CLIRB::Error, Sanford::ConfigFile::InvalidError => exception
         @kernel.puts "#{exception.message}\n\n"
         @kernel.puts help
@@ -40,8 +40,9 @@ module Sanford
 
     def run!(*args)
       @cli.parse!(args)
-      command          = @cli.args.pop || 'run'
-      config_file_path = @cli.args.pop || 'config.sanford'
+      config_file_path, command = @cli.args
+      config_file_path ||= 'config.sanford'
+      command ||= 'run'
       server = Sanford::ConfigFile.new(config_file_path).server
       case(command)
       when 'run'
@@ -58,9 +59,9 @@ module Sanford
     end
 
     def help
-      "Usage: sanford [CONFIG_FILE] [COMMAND]\n" \
-      "Commands: run, start, stop, restart" \
-      "#{@cli}"
+      "Usage: sanford [CONFIG_FILE] [COMMAND] [options]\n\n" \
+      "Commands: run, start, stop, restart\n" \
+      "Options: #{@cli}"
     end
 
   end


### PR DESCRIPTION
This updates the `CLI` behavior and output to match our latest
conventions. This includes a few small changes:
- Only output the version number when using the `--version` flag.
  This makes it easier to parse the actual version number and
  doesn't hurt the readability.
- Fix a minor behavior problem with only passing a config file.
  When this was done, the CLI would use the config file as the
  command instead of assuming `run` for the command and using
  the config file. This corrects that behavior.
- Update the output of the help message. This is a better
  explanation for using the command and matches our latest
  conventions.
- Code cleanups and updates to our match our latest conventions.

@kellyredding - Ready for review. Some cleanups that I noticed while using Sanford as reference for Qs.
