### PR TITLE
Fix a bug when inspecting a service handler

### DIFF
--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -37,7 +37,7 @@ module Sanford
 
       def inspect
         reference = '0x0%x' % (self.object_id << 1)
-        "#<#{self.class}:#{reference} @request=#{self.request.inspect}>"
+        "#<#{self.class}:#{reference} @request=#{request.inspect}>"
       end
 
       private

--- a/test/unit/service_handler_tests.rb
+++ b/test/unit/service_handler_tests.rb
@@ -144,9 +144,9 @@ module Sanford::ServiceHandler
     should have_imeths :init, :init!, :run, :run!
 
     should "know its request, params and logger" do
-      assert_equal @runner.request, subject.request
-      assert_equal @runner.params, subject.params
-      assert_equal @runner.logger, subject.logger
+      assert_equal @runner.request, subject.public_request
+      assert_equal @runner.params,  subject.public_params
+      assert_equal @runner.logger,  subject.public_logger
     end
 
     should "call `init!` and its before/after init callbacks using `init`" do
@@ -170,7 +170,7 @@ module Sanford::ServiceHandler
     should "have a custom inspect" do
       reference = '0x0%x' % (subject.object_id << 1)
       expected = "#<#{subject.class}:#{reference} " \
-                 "@request=#{subject.request.inspect}>"
+                 "@request=#{@runner.request.inspect}>"
       assert_equal expected, subject.inspect
     end
 
@@ -220,7 +220,7 @@ module Sanford::ServiceHandler
     # these methods are made public so they can be tested, they are being tested
     # because they are used by classes that mixin this, essentially they are
     # "public" to classes that use the mixin
-    public :render, :halt, :request, :params, :logger
+    public :render, :halt
 
     before_init{ @first_before_init_call_order = next_call_order }
     before_init{ @second_before_init_call_order = next_call_order }
@@ -240,6 +240,18 @@ module Sanford::ServiceHandler
 
     def run!
       @run_call_order = next_call_order
+    end
+
+    def public_request
+      request
+    end
+
+    def public_params
+      params
+    end
+
+    def public_logger
+      logger
     end
 
     private


### PR DESCRIPTION
This fixes a bug when inspecting a service handler. The previous
implementation called a private method with `self.` which caused
it to throw an error. This didn't fail in the tests because they
were previously making the request, params and logger public.
This changes the tests to not rely on making these public so the
inspect method would fail. This was a particularly annoying
issue when testing handlers because they are inspected by
default.

Closes #139

@kellyredding - Ready for review.
