### PR TITLE
update server data to include all of the server config data; cleanups

### DIFF
--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -266,8 +266,9 @@ module Sanford
 
       def to_hash
         super.merge({
-          :init_procs => self.init_procs,
+          :init_procs  => self.init_procs,
           :error_procs => self.error_procs,
+          :router => self.router,
           :routes => self.routes
         })
       end

--- a/lib/sanford/server_data.rb
+++ b/lib/sanford/server_data.rb
@@ -10,24 +10,29 @@ module Sanford
     attr_reader :name
     attr_reader :ip, :port
     attr_reader :pid_file
-    attr_reader :logger, :verbose_logging
     attr_reader :receives_keep_alive
-    attr_reader :error_procs
-    attr_reader :routes
-    attr_reader :template_source
+    attr_reader :verbose_logging, :logger, :template_source
+    attr_reader :init_procs, :error_procs
+    attr_reader :router, :routes
 
     def initialize(args = nil)
       args ||= {}
-      @name = args[:name]
-      @ip   = args[:ip]
-      @port = args[:port]
+      @name     = args[:name]
+      @ip       = args[:ip]
+      @port     = args[:port]
       @pid_file = args[:pid_file]
-      @logger = args[:logger]
-      @verbose_logging = !!args[:verbose_logging]
+
       @receives_keep_alive = !!args[:receives_keep_alive]
-      @error_procs = args[:error_procs] || []
-      @routes = build_routes(args[:routes] || [])
+
+      @verbose_logging = !!args[:verbose_logging]
+      @logger          = args[:logger]
       @template_source = args[:template_source]
+
+      @init_procs  = args[:init_procs]  || []
+      @error_procs = args[:error_procs] || []
+
+      @router = args[:router]
+      @routes = build_routes(args[:routes] || [])
     end
 
     def route_for(name)

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -8,25 +8,35 @@ class Sanford::ServerData
   class UnitTests < Assert::Context
     desc "Sanford::ServerData"
     setup do
-      @name = Factory.string
-      @ip = Factory.string
-      @port = Factory.integer
+      @name     = Factory.string
+      @ip       = Factory.string
+      @port     = Factory.integer
       @pid_file = Factory.file_path
-      @logger = Factory.string
-      @verbose_logging = Factory.boolean
+
       @receives_keep_alive = Factory.boolean
-      @error_procs = [ proc{ } ]
-      @route = Sanford::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
+
+      @verbose_logging = Factory.boolean
+      @logger          = Factory.string
+      @template_source = Factory.string
+
+      @init_procs  = [ proc{} ]
+      @error_procs = [ proc{} ]
+
+      @router = Factory.string
+      @route  = Sanford::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
 
       @server_data = Sanford::ServerData.new({
-        :name => @name,
-        :ip => @ip,
-        :port => @port,
+        :name     => @name,
+        :ip       => @ip,
+        :port     => @port,
         :pid_file => @pid_file,
-        :logger => @logger,
-        :verbose_logging => @verbose_logging,
         :receives_keep_alive => @receives_keep_alive,
+        :verbose_logging => @verbose_logging,
+        :logger          => @logger,
+        :template_source => @template_source,
+        :init_procs  => @init_procs,
         :error_procs => @error_procs,
+        :router => @router,
         :routes => [ @route ]
       })
     end
@@ -35,20 +45,27 @@ class Sanford::ServerData
     should have_readers :name
     should have_readers :ip, :port
     should have_readers :pid_file
-    should have_readers :logger, :verbose_logging
     should have_readers :receives_keep_alive
-    should have_readers :error_procs
-    should have_readers :routes
+    should have_readers :verbose_logging, :logger, :template_source
+    should have_readers :init_procs, :error_procs
+    should have_readers :router, :routes
 
     should "know its attributes" do
-      assert_equal @name, subject.name
-      assert_equal @ip, subject.ip
-      assert_equal @port, subject.port
+      assert_equal @name,     subject.name
+      assert_equal @ip,       subject.ip
+      assert_equal @port,     subject.port
       assert_equal @pid_file, subject.pid_file
-      assert_equal @logger, subject.logger
-      assert_equal @verbose_logging, subject.verbose_logging
+
       assert_equal @receives_keep_alive, subject.receives_keep_alive
+
+      assert_equal @verbose_logging, subject.verbose_logging
+      assert_equal @logger,          subject.logger
+      assert_equal @template_source, subject.template_source
+
+      assert_equal @init_procs,  subject.error_procs
       assert_equal @error_procs, subject.error_procs
+
+      assert_equal @router, subject.router
     end
 
     should "build a routes lookup hash" do
@@ -73,10 +90,17 @@ class Sanford::ServerData
       assert_nil server_data.ip
       assert_nil server_data.port
       assert_nil server_data.pid_file
-      assert_nil server_data.logger
-      assert_false server_data.verbose_logging
+
       assert_false server_data.receives_keep_alive
+
+      assert_false server_data.verbose_logging
+      assert_nil   server_data.logger
+      assert_nil   server_data.template_source
+
+      assert_equal [], server_data.init_procs
       assert_equal [], server_data.error_procs
+
+      assert_nil       server_data.router
       assert_equal({}, server_data.routes)
     end
 

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -448,10 +448,11 @@ module Sanford::Server
       assert_equal subject.router.routes, subject.routes
     end
 
-    should "include its init/error procs and routes in its hash representation" do
+    should "include its init/error procs and router/routes in its `to_hash`" do
       config_hash = subject.to_hash
       assert_equal subject.init_procs, config_hash[:init_procs]
       assert_equal subject.error_procs, config_hash[:error_procs]
+      assert_equal subject.router, config_hash[:router]
       assert_equal subject.routes, config_hash[:routes]
     end
 


### PR DESCRIPTION
This updates the server data to include _all_ of the server config
data.  This includes both the init procs and the router.  All data
should be available in server data as it is passed down via the
connection handler and route to the runner/handler.  This allows
for future features on this data without having to later pipe them
down.

This also follows the convention in Deas of passing all its data
down to the handlers.

No behavior changes b/c nothing currently relies on this data being
there.  This is just making things consistent and not arbitrarily
choosing what data is included.  This also has a bunch of test cleanups.
Attributes previously were not ordered consistently between the server
config and server data.  Also there were some missing attribute
tests (like template source, etc).

@jcredding ready for review.
