### PR TITLE
runners: switch to getting standard args from a passed in hash

### DIFF
--- a/lib/sanford/route.rb
+++ b/lib/sanford/route.rb
@@ -17,7 +17,13 @@ module Sanford
     end
 
     def run(request, server_data)
-      SanfordRunner.new(self.handler_class, request, server_data).run
+      SanfordRunner.new(self.handler_class, {
+        :request => request,
+        :params  => request.params,
+        :logger  => server_data.logger,
+        :router  => server_data.router,
+        :template_source => server_data.template_source
+      }).run
     end
 
     private

--- a/lib/sanford/runner.rb
+++ b/lib/sanford/runner.rb
@@ -1,5 +1,11 @@
+# need to define class immediately b/c of circular requires:
+# - runner -> router -> route -> sanford_runner -> runner
+module Sanford; end
+class Sanford::Runner; end
+
 require 'sanford-protocol'
 require 'sanford/logger'
+require 'sanford/router'
 require 'sanford/template_source'
 
 module Sanford
@@ -9,11 +15,18 @@ module Sanford
     ResponseArgs = Struct.new(:status, :data)
 
     attr_reader :handler_class, :handler
-    attr_reader :request, :params, :logger, :template_source
+    attr_reader :request, :params, :logger, :router, :template_source
 
-    def initialize(handler_class)
+    def initialize(handler_class, args = nil)
       @handler_class = handler_class
       @handler = @handler_class.new(self)
+
+      a = args || {}
+      @request         = a[:request]
+      @params          = a[:params] || {}
+      @logger          = a[:logger] || Sanford::NullLogger.new
+      @router          = a[:router] || Sanford::Router.new
+      @template_source = a[:template_source] || Sanford::NullTemplateSource.new
     end
 
     def run

--- a/lib/sanford/sanford_runner.rb
+++ b/lib/sanford/sanford_runner.rb
@@ -2,19 +2,7 @@ require 'sanford/runner'
 
 module Sanford
 
-  class SanfordRunner < Sanford::Runner
-
-    def initialize(handler_class, request, server_data)
-      @request         = request
-      @params          = @request.params
-      @logger          = server_data.logger
-      @template_source = server_data.template_source
-
-      super(handler_class)
-    end
-
-    # call the handler init and the handler run - if the init halts, run won't
-    # be called.
+  class SanfordRunner < Runner
 
     def run
       build_response do

--- a/lib/sanford/test_runner.rb
+++ b/lib/sanford/test_runner.rb
@@ -1,14 +1,12 @@
 require 'sanford-protocol'
-require 'sanford/logger'
 require 'sanford/runner'
 require 'sanford/service_handler'
-require 'sanford/template_source'
 
 module Sanford
 
   InvalidServiceHandlerError = Class.new(StandardError)
 
-  class TestRunner < Sanford::Runner
+  class TestRunner < Runner
 
     attr_reader :response
 
@@ -17,14 +15,15 @@ module Sanford
         raise InvalidServiceHandlerError, "#{handler_class.inspect} is not a"\
                                           " Sanford::ServiceHandler"
       end
-      args = (args || {}).dup
-      @request         = args.delete(:request)
-      @params          = args.delete(:params) || {}
-      @logger          = args.delete(:logger) || Sanford::NullLogger.new
-      @template_source = args.delete(:template_source) ||
-                         Sanford::NullTemplateSource.new
 
-      super(handler_class)
+      args = (args || {}).dup
+      super(handler_class, {
+        :request => args.delete(:request),
+        :params  => args.delete(:params),
+        :logger  => args.delete(:logger),
+        :router  => args.delete(:router),
+        :template_source => args.delete(:template_source)
+      })
       args.each{ |key, value| @handler.send("#{key}=", value) }
 
       return_value = catch(:halt){ @handler.init; nil }


### PR DESCRIPTION
This updates the runners to set their standard args from a given
hash.  This means all runners get their settings similarly and
don't reimplement gathering their settings.  This alson lines up
with how Deas/Qs handle their runners.

This is just a cleanup to make the code easier to understand and
work with.  This also makes it easier to pass down data from the
route to the runners.  No behavior changes.

@jcredding ready for review.
