### PR TITLE
templates: engine logger, template source api to set

### DIFF
--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -172,11 +172,6 @@ module Sanford
         self.configuration.template_source(*args)
       end
 
-      def build_template_source(path, &block)
-        block ||= proc{ }
-        self.template_source TemplateSource.new(path).tap(&block)
-      end
-
     end
 
     class Connection

--- a/lib/sanford/template_engine.rb
+++ b/lib/sanford/template_engine.rb
@@ -1,14 +1,16 @@
 require 'pathname'
+require 'sanford/logger'
 
 module Sanford
 
   class TemplateEngine
 
-    attr_reader :source_path, :opts
+    attr_reader :source_path, :logger, :opts
 
     def initialize(opts = nil)
       @opts = opts || {}
       @source_path = Pathname.new(@opts['source_path'].to_s)
+      @logger = @opts['logger'] || Sanford::NullLogger.new
     end
 
     def render(path, service_handler, locals)

--- a/lib/sanford/template_source.rb
+++ b/lib/sanford/template_source.rb
@@ -1,3 +1,4 @@
+require 'sanford/logger'
 require 'sanford/template_engine'
 
 module Sanford
@@ -10,9 +11,12 @@ module Sanford
 
     attr_reader :path, :engines
 
-    def initialize(path)
+    def initialize(path, logger = nil)
       @path = path.to_s
-      @default_opts = { 'source_path' => @path }
+      @default_opts = {
+        'source_path' => @path,
+        'logger'      => logger || Sanford::NullLogger.new
+      }
       @engines = Hash.new{ |h,k| Sanford::NullTemplateEngine.new(@default_opts) }
     end
 
@@ -23,6 +27,10 @@ module Sanford
       end
       engine_opts = @default_opts.merge(registered_opts || {})
       @engines[input_ext.to_s] = engine_class.new(engine_opts)
+    end
+
+    def engine_for?(template_name)
+      @engines.keys.include?(get_template_ext(template_name))
     end
 
     def render(template_path, service_handler, locals)

--- a/test/support/app_server.rb
+++ b/test/support/app_server.rb
@@ -1,6 +1,6 @@
 require 'pathname'
-require 'sanford'
 require 'sanford-protocol'
+require 'sanford'
 
 if !defined?(ROOT_PATH)
   ROOT_PATH = Pathname.new(File.expand_path('../../..', __FILE__))
@@ -40,8 +40,9 @@ class AppServer
     service 'custom_error', 'CustomError'
   end
 
-  build_template_source ROOT_PATH.join('test/support').to_s do |s|
+  Sanford::TemplateSource.new(ROOT_PATH.join('test/support').to_s).tap do |s|
     s.engine 'erb', AppERBEngine
+    template_source s
   end
 
   error do |exception, server_data, request|

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -23,8 +23,7 @@ module Sanford::Server
     should have_imeths :receives_keep_alive
     should have_imeths :verbose_logging, :logger
     should have_imeths :init, :error
-    should have_imeths :router
-    should have_imeths :template_source, :build_template_source
+    should have_imeths :router, :template_source
 
     should "know its configuration" do
       config = subject.configuration
@@ -115,20 +114,6 @@ module Sanford::Server
       subject.template_source(new_template_source)
       assert_equal new_template_source, subject.configuration.template_source
       assert_equal new_template_source, subject.template_source
-    end
-
-    should "allow setting its template source with a path and block" do
-      new_path = Factory.string
-      yielded = nil
-      subject.build_template_source(new_path){ |s| yielded = s }
-      assert_equal new_path, subject.configuration.template_source.path
-      assert_equal subject.configuration.template_source, yielded
-    end
-
-    should "allow setting its template source with only a path" do
-      new_path = Factory.string
-      subject.build_template_source(new_path)
-      assert_equal new_path, subject.configuration.template_source.path
     end
 
   end

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -2,6 +2,7 @@ require 'assert'
 require 'sanford/template_engine'
 
 require 'pathname'
+require 'sanford/logger'
 require 'test/support/factory'
 
 class Sanford::TemplateEngine
@@ -17,7 +18,7 @@ class Sanford::TemplateEngine
     end
     subject{ @engine }
 
-    should have_readers :source_path, :opts
+    should have_readers :source_path, :logger, :opts
     should have_imeths :render
 
     should "default its source path" do
@@ -27,6 +28,16 @@ class Sanford::TemplateEngine
     should "allow custom source paths" do
       engine = Sanford::TemplateEngine.new('source_path' => @source_path)
       assert_equal Pathname.new(@source_path.to_s), engine.source_path
+    end
+
+    should "default its logger" do
+      assert_instance_of Sanford::NullLogger, subject.logger
+    end
+
+    should "allow custom loggers" do
+      logger = 'a-logger'
+      engine = Sanford::TemplateEngine.new('logger' => logger)
+      assert_equal logger, engine.logger
     end
 
     should "default the opts if none given" do


### PR DESCRIPTION
This allows all engines to access the source's logger (if any).  This
is so engines have the option of making this logger accessible in
templates.

This lines up with how Deas passes its logger to its templates.

Note: this also adds the `engine_for?` method to query if an engine
has been configured for a given extension.  This is to be consistent
with Deas' api.

@jcredding ready for review.
