### PR TITLE
move render logic to the runner; call with locals directly

### DIFF
--- a/lib/sanford/runner.rb
+++ b/lib/sanford/runner.rb
@@ -33,6 +33,10 @@ module Sanford
       raise NotImplementedError
     end
 
+    def render(path, locals = nil)
+      self.template_source.render(path, self.handler, locals || {})
+    end
+
     # It's best to keep what `halt` and `catch_halt` return in the same format.
     # Currently this is a `ResponseArgs` object. This is so no matter how the
     # block returns (either by throwing or running normally), you get the same

--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -44,16 +44,11 @@ module Sanford
 
       # Helpers
 
-      def render(path, options = nil)
-        options ||= {}
-        source = options['source'] || @sanford_runner.template_source
-        source.render(path, self, options['locals'] || {})
-      end
-
-      def halt(*args); @sanford_runner.halt(*args); end
-      def request;     @sanford_runner.request;     end
-      def params;      @sanford_runner.params;      end
-      def logger;      @sanford_runner.logger;      end
+      def render(*args); @sanford_runner.render(*args); end
+      def halt(*args);   @sanford_runner.halt(*args);   end
+      def request;       @sanford_runner.request;       end
+      def params;        @sanford_runner.params;        end
+      def logger;        @sanford_runner.logger;        end
 
       def run_callback(callback)
         (self.class.send("#{callback}_callbacks") || []).each do |callback|


### PR DESCRIPTION
This moves the render logic from the service handler to the runner
and has the service handler just delegate to the runner.  This better
lines up with how the `halt` method is implemented and also lines
up with how Deas renders.

In addition, this changes the render call so that locals are passed
directly.  Before they were passed as a nested option.  The template
render system takes direct locals so this lines up better with that.
Also, Deas is moving to taking direct locals.  This does mean that
you can no longer pass custom template sources at render-time.  This
has yet to be used in production and its need is questionable.

@jcredding ready for review.
