### PR TITLE
rework template source api for querying about configured engines

### DIFF
--- a/lib/sanford/template_source.rb
+++ b/lib/sanford/template_source.rb
@@ -29,8 +29,12 @@ module Sanford
       @engines[input_ext.to_s] = engine_class.new(engine_opts)
     end
 
-    def engine_for?(template_name)
-      @engines.keys.include?(get_template_ext(template_name))
+    def engine_for?(ext)
+      @engines.keys.include?(ext)
+    end
+
+    def engine_for_template?(template_name)
+      self.engine_for?(get_template_ext(template_name))
     end
 
     def render(template_path, service_handler, locals)

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -26,7 +26,8 @@ class Sanford::TemplateSource
     subject{ @source }
 
     should have_readers :path, :engines
-    should have_imeths :engine, :engine_for?, :render
+    should have_imeths :engine, :engine_for?, :engine_for_template?
+    should have_imeths :render
 
     should "know its path" do
       assert_equal @source_path.to_s, subject.path
@@ -86,10 +87,14 @@ class Sanford::TemplateSource
     end
 
     should "know if it has an engine registered for a given template name" do
-      assert_false subject.engine_for?('test_template')
+      assert_false subject.engine_for?(Factory.string)
+      assert_false subject.engine_for?('test')
+      assert_false subject.engine_for_template?(Factory.string)
+      assert_false subject.engine_for_template?('test_template')
 
       subject.engine 'test', @test_engine
-      assert_true subject.engine_for?('test_template')
+      assert_true subject.engine_for?('test')
+      assert_true subject.engine_for_template?('test_template')
     end
 
   end


### PR DESCRIPTION
This reworks the `engine_for?` method to just take an extension
as an argument.  It then adds an `engine_for_template?` method that
works like the prev engine for method did.

The goal here is to be able to query whether an engine has been
configured when you already know the extension while keeping the
old ability to query when you don't know the extension but know the
template.

@jcredding this is just like what I did for Deas, FYI.  Ready for review.