### PR TITLE
Change restart cmd to check if `ENV['PWD']` is set

### DIFF
--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -212,8 +212,8 @@ class Sanford::Process
       assert_true @server_spy.thread.join_called
     end
 
-    should "not have exec'd the restart cmd" do
-      assert_false @restart_cmd_spy.exec_called
+    should "not run the restart cmd" do
+      assert_false @restart_cmd_spy.run_called
     end
 
     should "have removed the PID file" do
@@ -297,15 +297,12 @@ class Sanford::Process
       @process.run
     end
 
-    should "have set env vars for execing the restart cmd" do
+    should "set env vars for restarting and run the restart cmd" do
       assert_equal @server_spy.file_descriptor.to_s, ENV['SANFORD_SERVER_FD']
       expected = @server_spy.client_file_descriptors.join(',')
       assert_equal expected, ENV['SANFORD_CLIENT_FDS']
       assert_equal 'yes', ENV['SANFORD_SKIP_DAEMONIZE']
-    end
-
-    should "have exec'd the restart cmd" do
-      assert_true @restart_cmd_spy.exec_called
+      assert_true @restart_cmd_spy.run_called
     end
 
   end
@@ -313,32 +310,85 @@ class Sanford::Process
   class RestartCmdTests < UnitTests
     desc "RestartCmd"
     setup do
-      @restart_cmd = Sanford::RestartCmd.new
+      @current_pwd = ENV['PWD']
+      ENV['PWD'] = Factory.path
 
-      @chdir_called = false
-      Assert.stub(Dir, :chdir).with(@restart_cmd.dir){ @chdir_called = true }
+      @ruby_pwd_stat = File.stat(Dir.pwd)
+      env_pwd_stat = File.stat('/dev/null')
+      Assert.stub(File, :stat).with(Dir.pwd){ @ruby_pwd_stat }
+      Assert.stub(File, :stat).with(ENV['PWD']){ env_pwd_stat }
 
-      @exec_called = false
-      Assert.stub(Kernel, :exec).with(*@restart_cmd.argv){ @exec_called = true }
+      @chdir_called_with = nil
+      Assert.stub(Dir, :chdir){ |*args| @chdir_called_with = args }
+
+      @exec_called_with = false
+      Assert.stub(Kernel, :exec){ |*args| @exec_called_with = args }
+
+      @cmd_class = Sanford::RestartCmd
+    end
+    teardown do
+      ENV['PWD'] = @current_pwd
     end
     subject{ @restart_cmd }
 
-    should have_readers :argv, :dir
+  end
 
-    should "know its argv and dir" do
-      expected = [ Gem.ruby, $0, ARGV ].flatten
-      assert_equal expected, subject.argv
+  class RestartCmdInitTests < RestartCmdTests
+    desc "when init"
+    setup do
+      @restart_cmd = @cmd_class.new
+    end
+
+    should have_readers :argv, :dir
+    should have_imeths :run
+
+    should "know its argv" do
+      assert_equal [Gem.ruby, $0, ARGV].flatten, subject.argv
+    end
+
+    should "change the dir and run a kernel exec when run" do
+      subject.run
+      assert_equal [subject.dir], @chdir_called_with
+      assert_equal subject.argv,  @exec_called_with
+    end
+
+  end
+
+  class RestartCmdWithPWDEnvNoMatchTests < RestartCmdTests
+    desc "when init with a PWD env variable that doesn't point to ruby working dir"
+    setup do
+      @restart_cmd = @cmd_class.new
+    end
+
+    should "know its dir" do
       assert_equal Dir.pwd, subject.dir
     end
 
-    should "change the dir when exec'd" do
-      subject.exec
-      assert_true @chdir_called
+  end
+
+  class RestartCmdWithPWDEnvInitTests < RestartCmdTests
+    desc "when init with a PWD env variable that points to the ruby working dir"
+    setup do
+      # make ENV['PWD'] point to the same file as Dir.pwd
+      Assert.stub(File, :stat).with(ENV['PWD']){ @ruby_pwd_stat }
+      @restart_cmd = @cmd_class.new
     end
 
-    should "kernel exec its argv when exec'd" do
-      subject.exec
-      assert_true @exec_called
+    should "know its dir" do
+      assert_equal ENV['PWD'], subject.dir
+    end
+
+  end
+
+  class RestartCmdWithNoPWDEnvInitTests < RestartCmdTests
+    desc "when init with a PWD env variable set"
+    setup do
+      ENV.delete('PWD')
+      @restart_cmd = @cmd_class.new
+    end
+
+    should "know its dir" do
+      assert_equal Dir.pwd, subject.dir
     end
 
   end
@@ -417,14 +467,14 @@ class Sanford::Process
   end
 
   class RestartCmdSpy
-    attr_reader :exec_called
+    attr_reader :run_called
 
     def initialize
-      @exec_called = false
+      @run_called = false
     end
 
-    def exec
-      @exec_called = true
+    def run
+      @run_called = true
     end
   end
 


### PR DESCRIPTION
This changes the restart cmd to check if `ENV['PWD']` is set
before it tries to stat it. This covers the rare case where the
env var isn't set, like when using sudo. This piece of code is
heavily influenced by puma and I copied this from them as well.

This also updates the `RestartCmd` and changes its `exec` method to
just `run`. This is simpler and fits more of our standard pattern
of initializing and running classes. This also reworks the tests to
properly test all the behavior with restart cmd. This wasn't done
previously most likely because it is relatively difficult to test
because of the number of stubs and because its mostly edge case
behavior.

@kellyredding - Ready for review. Same thing as in Qs.