### PR TITLE
Cleanup a few requires, tests and test descriptions

### DIFF
--- a/lib/sanford/connection_handler.rb
+++ b/lib/sanford/connection_handler.rb
@@ -2,7 +2,6 @@ require 'benchmark'
 require 'sanford-protocol'
 require 'sanford/error_handler'
 require 'sanford/logger'
-require 'sanford/runner'
 
 module Sanford
 

--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -1,6 +1,7 @@
 require 'dat-tcp'
 require 'ns-options'
 require 'ns-options/boolean'
+require 'pathname'
 require 'sanford-protocol'
 require 'socket'
 require 'sanford/logger'

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -87,8 +87,8 @@ class Sanford::Process
       ENV['SANFORD_PORT'] = ''
       ENV['SANFORD_SERVER_FD'] = ''
       process = @process_class.new(@server_spy)
-      assert_equal @server_spy.configured_ip, subject.server_ip
-      assert_equal @server_spy.configured_port, subject.server_port
+      assert_equal @server_spy.configured_ip, process.server_ip
+      assert_equal @server_spy.configured_port, process.server_port
       assert_nil process.server_fd
     end
 
@@ -105,7 +105,7 @@ class Sanford::Process
 
     should "not daemonize by default" do
       process = @process_class.new(@server_spy)
-      assert_false subject.daemonize?
+      assert_false process.daemonize?
     end
 
     should "daemonize if turned on" do

--- a/test/unit/route_tests.rb
+++ b/test/unit/route_tests.rb
@@ -16,6 +16,7 @@ class Sanford::Route
     subject{ @route }
 
     should have_readers :name, :handler_class_name, :handler_class
+    should have_imeths :validate!, :run
 
     should "know its name and handler class name" do
       assert_equal @name, subject.name

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -6,7 +6,7 @@ require 'test/support/factory'
 class Sanford::Router
 
   class UnitTests < Assert::Context
-    desc "Sanford::Host"
+    desc "Sanford::Router"
     setup do
       @router = Sanford::Router.new
     end

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -35,12 +35,6 @@ class Sanford::TestRunner
     should have_readers :response
     should have_imeths :run
 
-    should "raise an invalid error when not passed a service handler" do
-      assert_raises(Sanford::InvalidServiceHandlerError) do
-        @runner_class.new(Class.new)
-      end
-    end
-
     should "super its standard attributes" do
       assert_equal 'a-request',  subject.request
       assert_equal @params,      subject.params
@@ -54,16 +48,30 @@ class Sanford::TestRunner
       assert_equal 42, runner.handler.custom_value
     end
 
-    should "not have called its service handlers before callbacks" do
+    should "not call its service handler's before callbacks" do
       assert_nil subject.handler.before_called
     end
 
-    should "have called init on its service handler" do
+    should "call its service handler's init" do
       assert_true subject.handler.init_called
+    end
+
+    should "not run its service handler" do
+      assert_false subject.handler.run_called
+    end
+
+    should "not call its service handler's after callbacks" do
+      assert_nil subject.handler.after_called
     end
 
     should "not have a response by default" do
       assert_nil subject.response
+    end
+
+    should "raise an invalid error passed a non service handler" do
+      assert_raises(Sanford::InvalidServiceHandlerError) do
+        @runner_class.new(Class.new)
+      end
     end
 
   end
@@ -80,11 +88,11 @@ class Sanford::TestRunner
       assert_instance_of Sanford::Protocol::Response, subject
     end
 
-    should "have called run on its service handler" do
+    should "run its service handler" do
       assert_true @runner.handler.run_called
     end
 
-    should "not have called its service handlers after callbacks" do
+    should "not call its service handler's after callbacks" do
       assert_nil @runner.handler.after_called
     end
 


### PR DESCRIPTION
This cleans up a few requires, tests and some test descriptions.
These were noticed while developing other libraries and using
Sanford as reference. This doesn't change any functionality.

@kellyredding - Ready for review. I had these hanging around, some of them from working on Qs I think. Just an odd collection of cleanups.