### PR TITLE
Update `TestRunner` to normalize test params

### DIFF
--- a/lib/sanford/error_handler.rb
+++ b/lib/sanford/error_handler.rb
@@ -46,7 +46,7 @@ module Sanford
 
     def response_from_exception(exception)
       case(exception)
-      when Sanford::Protocol::BadMessageError, Sanford::Protocol::BadRequestError
+      when Sanford::Protocol::BadMessageError, Sanford::Protocol::Request::InvalidError
         build_response :bad_request, :message => exception.message
       when Sanford::NotFoundError
         build_response :not_found

--- a/sanford.gemspec
+++ b/sanford.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency("dat-tcp",          ["~> 0.6"])
   gem.add_dependency("ns-options",       ["~> 1.1"])
-  gem.add_dependency("sanford-protocol", ["~> 0.10"])
+  gem.add_dependency("sanford-protocol", ["~> 0.11"])
 
   gem.add_development_dependency("assert", ["~> 2.12"])
 end

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -99,8 +99,8 @@ class Sanford::ErrorHandler
       assert_equal 'bad message', response.status.message
     end
 
-    should "build a 400 response with a protocol BadRequestError" do
-      exception = generate_exception(Sanford::Protocol::BadRequestError, 'bad request')
+    should "build a 400 response with a protocol request invalid error" do
+      exception = generate_exception(Sanford::Protocol::Request::InvalidError, 'bad request')
       response = Sanford::ErrorHandler.new(exception, @server_data).run
 
       assert_equal 400, response.code


### PR DESCRIPTION
This updates the `TestRunner` to normalize test params. This
stringifies them and then encodes and decodes them. The goal is
to ensure the params are valid and would work in a real request.

This also updates to work with the latest sanford-protocl. This
involved renaming the `BadRequestError` to `Request::InvalidError`.

Closes #154 

@kellyredding - Ready for review.