### PR TITLE
Update runner to build its handler after settings its own attrs

### DIFF
--- a/lib/sanford/runner.rb
+++ b/lib/sanford/runner.rb
@@ -19,7 +19,6 @@ module Sanford
 
     def initialize(handler_class, args = nil)
       @handler_class = handler_class
-      @handler = @handler_class.new(self)
 
       a = args || {}
       @request         = a[:request]
@@ -27,6 +26,8 @@ module Sanford
       @logger          = a[:logger] || Sanford::NullLogger.new
       @router          = a[:router] || Sanford::Router.new
       @template_source = a[:template_source] || Sanford::NullTemplateSource.new
+
+      @handler = @handler_class.new(self)
     end
 
     def run

--- a/sanford.gemspec
+++ b/sanford.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |gem|
   gem.add_dependency("ns-options",       ["~> 1.1"])
   gem.add_dependency("sanford-protocol", ["~> 0.11"])
 
-  gem.add_development_dependency("assert", ["~> 2.12"])
+  gem.add_development_dependency("assert", ["~> 2.14"])
 end


### PR DESCRIPTION
This is a small change that moves building the handler after the
runner has set its attributes. This is because the handler takes
the runner when it is initialized. If it wanted to use the
attributes from the runner in its initialize it wouldn't be able
to. By moving building the handler to the end of the runners
initialize the runner is "ready to go" by the time it passes it
to the handler.

This is a small change that came from Qs. Qs handlers needed to
user their runner in their initialize. This is being to be
consistent and because its a better default since the handler is
passed the runner. It avoids the scenario where, here is the
runner, but you can't use it yet cause we haven't finished
initializing it.

This also updates to the latest version of assert.

@kellyredding - Ready for review.