### PR TITLE
Move ip and port env vars usage into server configuration

### DIFF
--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -83,6 +83,8 @@ module Sanford
         @dat_tcp_server.listen(*args) do |server_socket|
           configure_tcp_server(server_socket)
         end
+        @server_data.ip   = self.ip
+        @server_data.port = self.port
       end
 
       def start(*args)
@@ -244,7 +246,7 @@ module Sanford
       include NsOptions::Proxy
 
       option :name,     String,  :required => true
-      option :ip,       String,  :required => true, :default => '0.0.0.0'
+      option :ip,       String,  :required => true
       option :port,     Integer, :required => true
       option :pid_file, Pathname
 
@@ -259,6 +261,8 @@ module Sanford
 
       def initialize(values = nil)
         super(values)
+        self.ip   = !(v = ENV['SANFORD_IP'].to_s).empty?   ? v : '0.0.0.0'
+        self.port = !(v = ENV['SANFORD_PORT'].to_s).empty? ? v : nil
         @init_procs, @error_procs = [], []
         @router = Sanford::Router.new
         @valid = nil
@@ -272,8 +276,8 @@ module Sanford
         super.merge({
           :init_procs  => self.init_procs,
           :error_procs => self.error_procs,
-          :router => self.router,
-          :routes => self.routes
+          :router      => self.router,
+          :routes      => self.routes
         })
       end
 

--- a/lib/sanford/server_data.rb
+++ b/lib/sanford/server_data.rb
@@ -8,12 +8,12 @@ module Sanford
     # NsOptions overhead when reading them while handling a request.
 
     attr_reader :name
-    attr_reader :ip, :port
     attr_reader :pid_file
     attr_reader :receives_keep_alive
     attr_reader :verbose_logging, :logger, :template_source
     attr_reader :init_procs, :error_procs
     attr_reader :router, :routes
+    attr_accessor :ip, :port
 
     def initialize(args = nil)
       args ||= {}

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -18,13 +18,9 @@ class Sanford::Process
   class InitTests < UnitTests
     desc "when init"
     setup do
-      @current_env_ip = ENV['SANFORD_IP']
-      @current_env_port = ENV['SANFORD_PORT']
-      @current_env_server_fd = ENV['SANFORD_SERVER_FD']
-      @current_env_client_fds = ENV['SANFORD_CLIENT_FDS']
+      @current_env_server_fd      = ENV['SANFORD_SERVER_FD']
+      @current_env_client_fds     = ENV['SANFORD_CLIENT_FDS']
       @current_env_skip_daemonize = ENV['SANFORD_SKIP_DAEMONIZE']
-      ENV.delete('SANFORD_IP')
-      ENV.delete('SANFORD_PORT')
       ENV.delete('SANFORD_SERVER_FD')
       ENV.delete('SANFORD_CLIENT_FDS')
       ENV.delete('SANFORD_SKIP_DAEMONIZE')
@@ -43,10 +39,8 @@ class Sanford::Process
     end
     teardown do
       ENV['SANFORD_SKIP_DAEMONIZE'] = @current_env_skip_daemonize
-      ENV['SANFORD_CLIENT_FDS'] = @current_env_client_fds
-      ENV['SANFORD_SERVER_FD'] = @current_env_server_fd
-      ENV['SANFORD_PORT'] = @current_env_ip
-      ENV['SANFORD_IP'] = @current_env_port
+      ENV['SANFORD_CLIENT_FDS']     = @current_env_client_fds
+      ENV['SANFORD_SERVER_FD']      = @current_env_server_fd
     end
     subject{ @process }
 
@@ -72,23 +66,17 @@ class Sanford::Process
       assert_nil subject.server_fd
     end
 
-    should "set its server ip, port and file descriptor using env vars" do
-      ENV['SANFORD_IP'] = Factory.string
-      ENV['SANFORD_PORT'] = Factory.integer.to_s
+    should "allow overriding its file descriptor using an env var" do
       ENV['SANFORD_SERVER_FD'] = Factory.integer.to_s
       process = @process_class.new(@server_spy)
-      assert_equal ENV['SANFORD_IP'], process.server_ip
-      assert_equal ENV['SANFORD_PORT'].to_i, process.server_port
       assert_equal ENV['SANFORD_SERVER_FD'].to_i, process.server_fd
-    end
 
-    should "ignore blank env values for its server ip, port and fd" do
-      ENV['SANFORD_IP'] = ''
-      ENV['SANFORD_PORT'] = ''
       ENV['SANFORD_SERVER_FD'] = ''
       process = @process_class.new(@server_spy)
-      assert_equal @server_spy.configured_ip, process.server_ip
-      assert_equal @server_spy.configured_port, process.server_port
+      assert_nil process.server_fd
+
+      ENV.delete('SANFORD_SERVER_FD')
+      process = @process_class.new(@server_spy)
       assert_nil process.server_fd
     end
 
@@ -97,7 +85,7 @@ class Sanford::Process
     end
 
     should "set its client file descriptors using an env var" do
-      client_fds = [ Factory.integer, Factory.integer ]
+      client_fds = [Factory.integer, Factory.integer]
       ENV['SANFORD_CLIENT_FDS'] = client_fds.join(',')
       process = @process_class.new(@server_spy)
       assert_equal client_fds, process.client_fds

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -19,36 +19,36 @@ class Sanford::ServerData
       @logger          = Factory.string
       @template_source = Factory.string
 
-      @init_procs  = [ proc{} ]
-      @error_procs = [ proc{} ]
+      @init_procs  = [proc{}]
+      @error_procs = [proc{}]
 
       @router = Factory.string
       @route  = Sanford::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
 
       @server_data = Sanford::ServerData.new({
-        :name     => @name,
-        :ip       => @ip,
-        :port     => @port,
-        :pid_file => @pid_file,
+        :name                => @name,
+        :ip                  => @ip,
+        :port                => @port,
+        :pid_file            => @pid_file,
         :receives_keep_alive => @receives_keep_alive,
-        :verbose_logging => @verbose_logging,
-        :logger          => @logger,
-        :template_source => @template_source,
-        :init_procs  => @init_procs,
-        :error_procs => @error_procs,
-        :router => @router,
-        :routes => [ @route ]
+        :verbose_logging     => @verbose_logging,
+        :logger              => @logger,
+        :template_source     => @template_source,
+        :init_procs          => @init_procs,
+        :error_procs         => @error_procs,
+        :router              => @router,
+        :routes              => [@route]
       })
     end
     subject{ @server_data }
 
     should have_readers :name
-    should have_readers :ip, :port
     should have_readers :pid_file
     should have_readers :receives_keep_alive
     should have_readers :verbose_logging, :logger, :template_source
     should have_readers :init_procs, :error_procs
     should have_readers :router, :routes
+    should have_accessors :ip, :port
 
     should "know its attributes" do
       assert_equal @name,     subject.name


### PR DESCRIPTION
This moves the ip and port env vars from the process into the
server configuration. The benefit of this is the server data now
always knows the actual configured ip and port. Previously, if the
env vars were set, then the server data could return an incorrect
ip and port than what was actually being used. This also keeps the
same behavior of allowing the env vars to overwrite the daemons
configuration.

In addition to the env var changes, the server data was also
updated to have its ip and port once the server starts listening.
This is because there was another scenario where the server data
could return incorrect ip and port information. If the server file
descriptor env var is used then all ip and port configuration is
ignored. So it is possible for the server file descriptor to use a
different ip and port than what was configured which means the
server data would return incorrect data. By writing the ip and port
back to the server data after listening, we know the actual ip and
port being used. The server file descriptor is primarily used for
restarting a sanford process so its not likely that it won't match
what was originally configured but it is possible.

@kellyredding - Ready for review.