### PR TITLE
Allow setting dat-tcp worker callbacks

### DIFF
--- a/lib/sanford/server_data.rb
+++ b/lib/sanford/server_data.rb
@@ -12,6 +12,8 @@ module Sanford
     attr_reader :receives_keep_alive
     attr_reader :verbose_logging, :logger, :template_source
     attr_reader :init_procs, :error_procs
+    attr_reader :worker_start_procs, :worker_shutdown_procs
+    attr_reader :worker_sleep_procs, :worker_wakeup_procs
     attr_reader :router, :routes
     attr_accessor :ip, :port
 
@@ -30,6 +32,11 @@ module Sanford
 
       @init_procs  = args[:init_procs]  || []
       @error_procs = args[:error_procs] || []
+
+      @worker_start_procs    = args[:worker_start_procs]
+      @worker_shutdown_procs = args[:worker_shutdown_procs]
+      @worker_sleep_procs    = args[:worker_sleep_procs]
+      @worker_wakeup_procs   = args[:worker_wakeup_procs]
 
       @router = args[:router]
       @routes = build_routes(args[:routes] || [])

--- a/sanford.gemspec
+++ b/sanford.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency("dat-tcp",          ["~> 0.6"])
+  gem.add_dependency("dat-tcp",          ["~> 0.7"])
   gem.add_dependency("ns-options",       ["~> 1.1"])
   gem.add_dependency("sanford-protocol", ["~> 0.11"])
 
-  gem.add_development_dependency("assert", ["~> 2.14"])
+  gem.add_development_dependency("assert", ["~> 2.15"])
 end

--- a/test/support/app_server.rb
+++ b/test/support/app_server.rb
@@ -21,7 +21,7 @@ class AppServer
   include Sanford::Server
 
   name 'app'
-  ip   'localhost'
+  ip   '127.0.0.1'
   port 12000
 
   receives_keep_alive true

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -19,25 +19,34 @@ class Sanford::ServerData
       @logger          = Factory.string
       @template_source = Factory.string
 
-      @init_procs  = [proc{}]
-      @error_procs = [proc{}]
+      @init_procs  = Factory.integer(3).times.map{ proc{} }
+      @error_procs = Factory.integer(3).times.map{ proc{} }
+
+      @start_procs    = Factory.integer(3).times.map{ proc{} }
+      @shutdown_procs = Factory.integer(3).times.map{ proc{} }
+      @sleep_procs    = Factory.integer(3).times.map{ proc{} }
+      @wakeup_procs   = Factory.integer(3).times.map{ proc{} }
 
       @router = Factory.string
       @route  = Sanford::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
 
       @server_data = Sanford::ServerData.new({
-        :name                => @name,
-        :ip                  => @ip,
-        :port                => @port,
-        :pid_file            => @pid_file,
-        :receives_keep_alive => @receives_keep_alive,
-        :verbose_logging     => @verbose_logging,
-        :logger              => @logger,
-        :template_source     => @template_source,
-        :init_procs          => @init_procs,
-        :error_procs         => @error_procs,
-        :router              => @router,
-        :routes              => [@route]
+        :name                  => @name,
+        :ip                    => @ip,
+        :port                  => @port,
+        :pid_file              => @pid_file,
+        :receives_keep_alive   => @receives_keep_alive,
+        :verbose_logging       => @verbose_logging,
+        :logger                => @logger,
+        :template_source       => @template_source,
+        :init_procs            => @init_procs,
+        :error_procs           => @error_procs,
+        :worker_start_procs    => @start_procs,
+        :worker_shutdown_procs => @shutdown_procs,
+        :worker_sleep_procs    => @sleep_procs,
+        :worker_wakeup_procs   => @wakeup_procs,
+        :router                => @router,
+        :routes                => [@route]
       })
     end
     subject{ @server_data }
@@ -47,6 +56,8 @@ class Sanford::ServerData
     should have_readers :receives_keep_alive
     should have_readers :verbose_logging, :logger, :template_source
     should have_readers :init_procs, :error_procs
+    should have_readers :worker_start_procs, :worker_shutdown_procs
+    should have_readers :worker_sleep_procs, :worker_wakeup_procs
     should have_readers :router, :routes
     should have_accessors :ip, :port
 
@@ -62,8 +73,13 @@ class Sanford::ServerData
       assert_equal @logger,          subject.logger
       assert_equal @template_source, subject.template_source
 
-      assert_equal @init_procs,  subject.error_procs
+      assert_equal @init_procs,  subject.init_procs
       assert_equal @error_procs, subject.error_procs
+
+      assert_equal @start_procs,    subject.worker_start_procs
+      assert_equal @shutdown_procs, subject.worker_shutdown_procs
+      assert_equal @sleep_procs,    subject.worker_sleep_procs
+      assert_equal @wakeup_procs,   subject.worker_wakeup_procs
 
       assert_equal @router, subject.router
     end


### PR DESCRIPTION
This adds configuration and DSL methods for adding dat-tcp worker
callbacks for start, shutdown, sleep and wakeup. This allows
adding custom callbacks when the previous events happen on a worker
thread.

This will be used to set the thread id of any new workers on our
logger so each worker will log with its own thread id.

@kellyredding - Ready for review.