### PR TITLE
Update `ErrorHandler`, pass error context to error procs

### DIFF
--- a/test/support/app_server.rb
+++ b/test/support/app_server.rb
@@ -45,9 +45,10 @@ class AppServer
     template_source s
   end
 
-  error do |exception, server_data, request|
-    if request && request.name == 'custom_error'
-      data = "The server on #{server_data.ip}:#{server_data.port} " \
+  error do |exception, context|
+    if context.request && context.request.name == 'custom_error'
+      data = "The server on " \
+             "#{context.server_data.ip}:#{context.server_data.port} " \
              "threw a #{exception.class}."
       Sanford::Protocol::Response.new(200, data)
     end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -3,4 +3,12 @@ require 'assert/factory'
 module Factory
   extend Assert::Factory
 
+  def self.exception(klass = nil, message = nil)
+    klass ||= StandardError
+    message ||= Factory.text
+    exception = nil
+    begin; raise(klass, message); rescue StandardError => exception; end
+    exception
+  end
+
 end


### PR DESCRIPTION
This updates the `ErrorHandler` to pass an error context to its
error procs. It also updates the `ConnectionHandler` to pass its
handler class and response to the `ErrorHandler` so they can be
included in the context and passed to the error procs. This is to
provide more information to error procs.

In Qs we had a lot more information to pass to the error procs so
the pattern previously used in Sanford didn't work. Qs switched to
building a context and passing that to its error procs. This is a
better pattern because it is a simpler interface for the procs and
it is easier to expand. The previous pattern would keep appending
extra information as args to the procs. This is more difficult to
use because there are more args to remember their order and many
of them can be `nil` depending on where the error occurs. With the
context, there are 2 args, the exception and the context that it
happened in. The context is also easier to expand because new data
can be added without changing the error procs interface.

This also updates the connection handler to pass its handler class
and response to the error handler. This provides the error handler
with more contextual information to pass to the error procs which
can use the data however they need to.

This also includes some minor cleanups to the connection handler
and updates its summary logging to include an error if one
occurred. The verbose logging was already logging any exceptions
so it makes sense for the summary logging to do so as well.

@kellyredding - Ready for review. One minor thing I noticed but haven't addressed in this effort is that the connection handler tests do not have good coverage on what is passed to the error handler. I have made a note to rework the connection handler tests to handle this better in a future commit. The effect is I add the handler class and response to what is passed in the connection handler but no tests had to change.