### PR TITLE
Fix using an ip and port env vars

### DIFF
--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -79,7 +79,7 @@ module Sanford
       end
 
       def listen(*args)
-        args = [ @server_data.ip, @server_data.port ] if args.empty?
+        args = [@server_data.ip, @server_data.port] if args.empty?
         @dat_tcp_server.listen(*args) do |server_socket|
           configure_tcp_server(server_socket)
         end
@@ -274,7 +274,7 @@ module Sanford
       include NsOptions::Proxy
 
       option :name,     String,  :required => true
-      option :ip,       String,  :required => true
+      option :ip,       String,  :required => true, :default => '0.0.0.0'
       option :port,     Integer, :required => true
       option :pid_file, Pathname
 
@@ -291,8 +291,6 @@ module Sanford
 
       def initialize(values = nil)
         super(values)
-        self.ip   = !(v = ENV['SANFORD_IP'].to_s).empty?   ? v : '0.0.0.0'
-        self.port = !(v = ENV['SANFORD_PORT'].to_s).empty? ? v : nil
         @init_procs, @error_procs = [], []
         @worker_start_procs, @worker_shutdown_procs = [], []
         @worker_sleep_procs, @worker_wakeup_procs   = [], []

--- a/lib/sanford/server_data.rb
+++ b/lib/sanford/server_data.rb
@@ -20,8 +20,8 @@ module Sanford
     def initialize(args = nil)
       args ||= {}
       @name     = args[:name]
-      @ip       = args[:ip]
-      @port     = args[:port]
+      @ip       = !(v = ENV['SANFORD_IP'].to_s).empty?   ? v      : args[:ip]
+      @port     = !(v = ENV['SANFORD_PORT'].to_s).empty? ? v.to_i : args[:port]
       @pid_file = args[:pid_file]
 
       @receives_keep_alive = !!args[:receives_keep_alive]

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -223,23 +223,6 @@ class Sanford::Process
 
   end
 
-  class RunWithIPAndPortTests < RunSetupTests
-    desc "with a custom IP and port is run"
-    setup do
-      ENV['SANFORD_IP'] = Factory.string
-      ENV['SANFORD_PORT'] = Factory.integer.to_s
-      @process = @process_class.new(@server_spy)
-      @process.run
-    end
-
-    should "have used the custom IP and port when listening" do
-      assert_true @server_spy.listen_called
-      expected = [ @process.server_ip, @process.server_port ]
-      assert_equal expected, @server_spy.listen_args
-    end
-
-  end
-
   class RunWithServerFDTests < RunSetupTests
     desc "with a server file descriptor is run"
     setup do

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -8,46 +8,35 @@ class Sanford::ServerData
   class UnitTests < Assert::Context
     desc "Sanford::ServerData"
     setup do
-      @name     = Factory.string
-      @ip       = Factory.string
-      @port     = Factory.integer
-      @pid_file = Factory.file_path
+      @orig_ip_env_var   = ENV['SANFORD_IP']
+      @orig_port_env_var = ENV['SANFORD_PORT']
+      ENV.delete('SANFORD_IP')
+      ENV.delete('SANFORD_PORT')
 
-      @receives_keep_alive = Factory.boolean
-
-      @verbose_logging = Factory.boolean
-      @logger          = Factory.string
-      @template_source = Factory.string
-
-      @init_procs  = Factory.integer(3).times.map{ proc{} }
-      @error_procs = Factory.integer(3).times.map{ proc{} }
-
-      @start_procs    = Factory.integer(3).times.map{ proc{} }
-      @shutdown_procs = Factory.integer(3).times.map{ proc{} }
-      @sleep_procs    = Factory.integer(3).times.map{ proc{} }
-      @wakeup_procs   = Factory.integer(3).times.map{ proc{} }
-
-      @router = Factory.string
-      @route  = Sanford::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
-
-      @server_data = Sanford::ServerData.new({
-        :name                  => @name,
-        :ip                    => @ip,
-        :port                  => @port,
-        :pid_file              => @pid_file,
-        :receives_keep_alive   => @receives_keep_alive,
-        :verbose_logging       => @verbose_logging,
-        :logger                => @logger,
-        :template_source       => @template_source,
-        :init_procs            => @init_procs,
-        :error_procs           => @error_procs,
-        :worker_start_procs    => @start_procs,
-        :worker_shutdown_procs => @shutdown_procs,
-        :worker_sleep_procs    => @sleep_procs,
-        :worker_wakeup_procs   => @wakeup_procs,
-        :router                => @router,
+      @route = Sanford::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
+      @config_hash = {
+        :name                  => Factory.string,
+        :ip                    => Factory.string,
+        :port                  => Factory.integer,
+        :pid_file              => Factory.file_path,
+        :receives_keep_alive   => Factory.boolean,
+        :verbose_logging       => Factory.boolean,
+        :logger                => Factory.string,
+        :template_source       => Factory.string,
+        :init_procs            => Factory.integer(3).times.map{ proc{} },
+        :error_procs           => Factory.integer(3).times.map{ proc{} },
+        :worker_start_procs    => Factory.integer(3).times.map{ proc{} },
+        :worker_shutdown_procs => Factory.integer(3).times.map{ proc{} },
+        :worker_sleep_procs    => Factory.integer(3).times.map{ proc{} },
+        :worker_wakeup_procs   => Factory.integer(3).times.map{ proc{} },
+        :router                => Factory.string,
         :routes                => [@route]
-      })
+      }
+      @server_data = Sanford::ServerData.new(@config_hash)
+    end
+    teardown do
+      ENV['SANFORD_IP']   = @orig_ip_env_var
+      ENV['SANFORD_PORT'] = @orig_port_env_var
     end
     subject{ @server_data }
 
@@ -62,26 +51,41 @@ class Sanford::ServerData
     should have_accessors :ip, :port
 
     should "know its attributes" do
-      assert_equal @name,     subject.name
-      assert_equal @ip,       subject.ip
-      assert_equal @port,     subject.port
-      assert_equal @pid_file, subject.pid_file
+      h = @config_hash
+      assert_equal h[:name],     subject.name
+      assert_equal h[:ip],       subject.ip
+      assert_equal h[:port],     subject.port
+      assert_equal h[:pid_file], subject.pid_file
 
-      assert_equal @receives_keep_alive, subject.receives_keep_alive
+      assert_equal h[:receives_keep_alive], subject.receives_keep_alive
 
-      assert_equal @verbose_logging, subject.verbose_logging
-      assert_equal @logger,          subject.logger
-      assert_equal @template_source, subject.template_source
+      assert_equal h[:verbose_logging], subject.verbose_logging
+      assert_equal h[:logger],          subject.logger
+      assert_equal h[:template_source], subject.template_source
 
-      assert_equal @init_procs,  subject.init_procs
-      assert_equal @error_procs, subject.error_procs
+      assert_equal h[:init_procs],  subject.init_procs
+      assert_equal h[:error_procs], subject.error_procs
 
-      assert_equal @start_procs,    subject.worker_start_procs
-      assert_equal @shutdown_procs, subject.worker_shutdown_procs
-      assert_equal @sleep_procs,    subject.worker_sleep_procs
-      assert_equal @wakeup_procs,   subject.worker_wakeup_procs
+      assert_equal h[:worker_start_procs],    subject.worker_start_procs
+      assert_equal h[:worker_shutdown_procs], subject.worker_shutdown_procs
+      assert_equal h[:worker_sleep_procs],    subject.worker_sleep_procs
+      assert_equal h[:worker_wakeup_procs],   subject.worker_wakeup_procs
 
-      assert_equal @router, subject.router
+      assert_equal h[:router], subject.router
+    end
+
+    should "use ip and port env vars if they are set" do
+      ENV['SANFORD_IP']   = Factory.string
+      ENV['SANFORD_PORT'] = Factory.integer.to_s
+      server_data = Sanford::ServerData.new(@config_hash)
+      assert_equal ENV['SANFORD_IP'],        server_data.ip
+      assert_equal ENV['SANFORD_PORT'].to_i, server_data.port
+
+      ENV['SANFORD_IP']   = ""
+      ENV['SANFORD_PORT'] = ""
+      server_data = Sanford::ServerData.new(@config_hash)
+      assert_equal @config_hash[:ip],   server_data.ip
+      assert_equal @config_hash[:port], server_data.port
     end
 
     should "build a routes lookup hash" do

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -439,20 +439,11 @@ module Sanford::Server
 
     desc "Configuration"
     setup do
-      @orig_ip_env_var   = ENV['SANFORD_IP']
-      @orig_port_env_var = ENV['SANFORD_PORT']
-      ENV.delete('SANFORD_IP')
-      ENV.delete('SANFORD_PORT')
-
       @configuration = Configuration.new.tap do |c|
         c.name Factory.string
         c.ip   Factory.string
         c.port Factory.integer
       end
-    end
-    teardown do
-      ENV['SANFORD_IP']   = @orig_ip_env_var
-      ENV['SANFORD_PORT'] = @orig_port_env_var
     end
     subject{ @configuration }
 
@@ -495,15 +486,6 @@ module Sanford::Server
 
       assert_instance_of Sanford::Router, config.router
       assert_empty config.router.routes
-    end
-
-    should "use env vars for its options if they are set" do
-      ENV['SANFORD_IP']   = Factory.string
-      ENV['SANFORD_PORT'] = Factory.integer.to_s
-
-      config = Configuration.new
-      assert_equal ENV['SANFORD_IP'],        config.ip
-      assert_equal ENV['SANFORD_PORT'].to_i, config.port
     end
 
     should "not be valid by default" do


### PR DESCRIPTION
This fixes a bug with using ip and port env vars to configure
the ip and port the server listens on. The ip and port env vars
are intended as a way to overwrite any configuration and tell a
process to have its sanford server listen on an ip and port. The
previous implementation instead used them as a default. This
meant that the default value would be based on the env var but if
the servers configuration was changed it would be overwritten.

This fixes the bug by reverting to the old default ip and port
configuration logic and having the server data check for the ip
and port env var when its built. If it sees they are set, it will
use the env var instead of whats configured.

This also adds a system test to ensure that if we create a server
with the env vars set it uses them when binding to a socket. This
should ensure that if this logic moves the overall behavior still
works.

Finally, this also removes an old process test that used the ip
and port. This was a remnant of when the process would look for
the ip and port env vars and is no longer needed.

@kellyredding - Ready for review.