### PR TITLE
cleanups: consistency with Deas and Qs; prep for declarative responses

### DIFF
--- a/lib/sanford/runner.rb
+++ b/lib/sanford/runner.rb
@@ -15,27 +15,23 @@ module Sanford
     ResponseArgs = Struct.new(:status, :data)
 
     attr_reader :handler_class, :handler
-    attr_reader :request, :params, :logger, :router, :template_source
+    attr_reader :logger, :router, :template_source
+    attr_reader :request, :params
 
     def initialize(handler_class, args = nil)
       @handler_class = handler_class
-
-      a = args || {}
-      @request         = a[:request]
-      @params          = a[:params] || {}
-      @logger          = a[:logger] || Sanford::NullLogger.new
-      @router          = a[:router] || Sanford::Router.new
-      @template_source = a[:template_source] || Sanford::NullTemplateSource.new
-
       @handler = @handler_class.new(self)
+
+      args ||= {}
+      @logger          = args[:logger] || Sanford::NullLogger.new
+      @router          = args[:router] || Sanford::Router.new
+      @template_source = args[:template_source] || Sanford::NullTemplateSource.new
+      @request         = args[:request]
+      @params          = args[:params] || {}
     end
 
     def run
       raise NotImplementedError
-    end
-
-    def render(path, locals = nil)
-      self.template_source.render(path, self.handler, locals || {})
     end
 
     # It's best to keep what `halt` and `catch_halt` return in the same format.
@@ -49,6 +45,10 @@ module Sanford
       response_status = [ status, message ]
       response_data = options[:data] || options['data']
       throw :halt, ResponseArgs.new(response_status, response_data)
+    end
+
+    def render(path, locals = nil)
+      self.template_source.render(path, self.handler, locals || {})
     end
 
     private

--- a/lib/sanford/sanford_runner.rb
+++ b/lib/sanford/sanford_runner.rb
@@ -6,18 +6,12 @@ module Sanford
 
     def run
       build_response do
-        run_callbacks self.handler_class.before_callbacks
-        self.handler.init
-        return_value = self.handler.run
-        run_callbacks self.handler_class.after_callbacks
+        self.handler.sanford_run_callback 'before'
+        self.handler.sanford_init
+        return_value = self.handler.sanford_run
+        self.handler.sanford_run_callback 'after'
         return_value
       end
-    end
-
-    private
-
-    def run_callbacks(callbacks)
-      callbacks.each{ |proc| self.handler.instance_eval(&proc) }
     end
 
   end

--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -15,24 +15,29 @@ module Sanford
         @sanford_runner = runner
       end
 
-      def init
-        run_callback 'before_init'
+      def sanford_init
+        self.sanford_run_callback 'before_init'
         self.init!
-        run_callback 'after_init'
+        self.sanford_run_callback 'after_init'
       end
 
       def init!
       end
 
-      def run
-        run_callback 'before_run'
+      def sanford_run
+        self.sanford_run_callback 'before_run'
         data = self.run!
-        run_callback 'after_run'
-        [ 200, data ]
+        self.sanford_run_callback 'after_run'
+        [200, data]
       end
 
       def run!
-        raise NotImplementedError
+      end
+
+      def sanford_run_callback(callback)
+        (self.class.send("#{callback}_callbacks") || []).each do |callback|
+          self.instance_eval(&callback)
+        end
       end
 
       def inspect
@@ -48,17 +53,11 @@ module Sanford
 
       # Helpers
 
-      def render(*args); @sanford_runner.render(*args); end
-      def halt(*args);   @sanford_runner.halt(*args);   end
+      def logger;        @sanford_runner.logger;        end
       def request;       @sanford_runner.request;       end
       def params;        @sanford_runner.params;        end
-      def logger;        @sanford_runner.logger;        end
-
-      def run_callback(callback)
-        (self.class.send("#{callback}_callbacks") || []).each do |callback|
-          self.instance_eval(&callback)
-        end
-      end
+      def halt(*args);   @sanford_runner.halt(*args);   end
+      def render(*args); @sanford_runner.render(*args); end
 
     end
 

--- a/lib/sanford/test_runner.rb
+++ b/lib/sanford/test_runner.rb
@@ -12,21 +12,21 @@ module Sanford
 
     def initialize(handler_class, args = nil)
       if !handler_class.include?(Sanford::ServiceHandler)
-        raise InvalidServiceHandlerError, "#{handler_class.inspect} is not a"\
-                                          " Sanford::ServiceHandler"
+        raise InvalidServiceHandlerError, "#{handler_class.inspect} is not a " \
+                                          "Sanford::ServiceHandler"
       end
 
-      args = (args || {}).dup
+      a = (args || {}).dup
       super(handler_class, {
-        :request         => args.delete(:request),
-        :params          => normalize_params(args.delete(:params) || {}),
-        :logger          => args.delete(:logger),
-        :router          => args.delete(:router),
-        :template_source => args.delete(:template_source)
+        :logger          => a.delete(:logger),
+        :router          => a.delete(:router),
+        :template_source => a.delete(:template_source),
+        :request         => a.delete(:request),
+        :params          => normalize_params(a.delete(:params) || {})
       })
-      args.each{ |key, value| @handler.send("#{key}=", value) }
+      a.each{ |key, value| @handler.send("#{key}=", value) }
 
-      return_value = catch(:halt){ @handler.init; nil }
+      return_value = catch(:halt){ @handler.sanford_init; nil }
       @response = build_and_serialize_response{ return_value } if return_value
     end
 
@@ -35,7 +35,7 @@ module Sanford
     # `init` stops processing where `halt` is called.
 
     def run
-      @response ||= build_and_serialize_response{ self.handler.run }
+      @response ||= build_and_serialize_response{ self.handler.sanford_run }
     end
 
     private

--- a/test/unit/test_runner_tests.rb
+++ b/test/unit/test_runner_tests.rb
@@ -7,7 +7,7 @@ class Sanford::TestRunner
     desc "Sanford::TestRunner"
     setup do
       @handler_class = TestServiceHandler
-      @runner_class = Sanford::TestRunner
+      @runner_class  = Sanford::TestRunner
     end
     subject{ @runner_class }
 
@@ -22,11 +22,11 @@ class Sanford::TestRunner
     setup do
       @params = { Factory.string => Factory.integer }
       @args = {
-        :request         => Factory.string,
-        :params          => @params,
         :logger          => Factory.string,
         :router          => Factory.string,
         :template_source => Factory.string,
+        :request         => Factory.string,
+        :params          => @params,
         :custom_value    => Factory.integer
       }
       @original_args = @args.dup
@@ -38,35 +38,41 @@ class Sanford::TestRunner
     should have_readers :response
     should have_imeths :run
 
-    should "know its standard attributes" do
-      assert_equal @args[:request],         subject.request
-      assert_equal @params,                 subject.params
+    should "raise an invalid error when passed a non service handler" do
+      assert_raises(Sanford::InvalidServiceHandlerError) do
+        @runner_class.new(Class.new)
+      end
+    end
+
+    should "know its standard args" do
       assert_equal @args[:logger],          subject.logger
       assert_equal @args[:router],          subject.router
       assert_equal @args[:template_source], subject.template_source
+      assert_equal @args[:request],         subject.request
+      assert_equal @args[:params],          subject.params
     end
 
     should "write any non-standard args to its handler" do
-      assert_equal @args[:custom_value], @handler.custom_value
+      assert_equal @args[:custom_value], subject.handler.custom_value
     end
 
     should "not alter the args passed to it" do
       assert_equal @original_args, @args
     end
 
-    should "not call its service handlers before callbacks" do
+    should "not call its handler's before callbacks" do
       assert_nil @handler.before_called
     end
 
-    should "call its service handlers init" do
+    should "call its handler's init" do
       assert_true @handler.init_called
     end
 
-    should "not run its service handler" do
-      assert_false @handler.run_called
+    should "not call its handler's run" do
+      assert_nil @handler.run_called
     end
 
-    should "not call its service handlers after callbacks" do
+    should "not call its handler's after callbacks" do
       assert_nil @handler.after_called
     end
 
@@ -89,12 +95,6 @@ class Sanford::TestRunner
       params = { Factory.string => Class.new }
       assert_raises(BSON::InvalidDocument) do
         @runner_class.new(@handler_class, :params => params)
-      end
-    end
-
-    should "raise an invalid error when passed a non service handler" do
-      assert_raises(Sanford::InvalidServiceHandlerError) do
-        @runner_class.new(Class.new)
       end
     end
 
@@ -189,13 +189,13 @@ class Sanford::TestRunner
 
     def init!
       @init_called = true
-      @run_called = false
     end
 
     def run!
       @run_called = true
       @response || Factory.boolean
     end
+
   end
 
   class HaltServiceHandler
@@ -214,6 +214,7 @@ class Sanford::TestRunner
     def run!
       @run_called = true
     end
+
   end
 
 end


### PR DESCRIPTION
This touches up a bunch of minor things to get Sanford's handler pattern
implementation/tests consistent with Deas' and Qs'.  This includes:

* **making the handler `run!` a no-op**:  this allows you to implement
  all run related behavior in callbacks only if you choose. This is
  ideal if you need to put run logic into handler mixins but want to
  use callbacks b/c you aren't sure what other handler mixins may be
  in play
* **namespace non-user-facing handler methods**: since view handlers are
  intended to run user code, we want to be careful to not "pollute" the
  handler scope with our own methods that will break in spectacular ways
  if the user happens to override them
* **make run callback method public**: now that we are namespacing
  internal handler methods, we can make the run callback method public
  and use it in the sanford runner so we don't have to duplicate it
  for running the before/after callbacks.

This is all prep for switching Sanford to declare response values.  I
didn't want the "noise" of these efforts to convolute this coming effort.

@jcredding ready for review.