### PR TITLE
switch to declarative response handling

### DIFF
--- a/lib/sanford/sanford_runner.rb
+++ b/lib/sanford/sanford_runner.rb
@@ -5,13 +5,12 @@ module Sanford
   class SanfordRunner < Runner
 
     def run
-      build_response do
+      catch(:halt) do
         self.handler.sanford_run_callback 'before'
-        self.handler.sanford_init
-        return_value = self.handler.sanford_run
+        catch(:halt){ self.handler.sanford_init; self.handler.sanford_run }
         self.handler.sanford_run_callback 'after'
-        return_value
       end
+      self.to_response
     end
 
   end

--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -53,9 +53,16 @@ module Sanford
 
       # Helpers
 
-      def logger;        @sanford_runner.logger;        end
-      def request;       @sanford_runner.request;       end
-      def params;        @sanford_runner.params;        end
+      # utils
+      def logger; @sanford_runner.logger; end
+
+      # request
+      def request; @sanford_runner.request; end
+      def params;  @sanford_runner.params;  end
+
+      # response
+      def status(*args); @sanford_runner.status(*args); end
+      def data(*args);   @sanford_runner.data(*args);   end
       def halt(*args);   @sanford_runner.halt(*args);   end
       def render(*args); @sanford_runner.render(*args); end
 

--- a/test/support/app_server.rb
+++ b/test/support/app_server.rb
@@ -62,7 +62,7 @@ module AppHandlers
     include Sanford::ServiceHandler
 
     def run!
-      params['message']
+      data(params['message'])
     end
   end
 
@@ -78,7 +78,7 @@ module AppHandlers
     include Sanford::ServiceHandler
 
     def run!
-      Class.new
+      data(Class.new)
     end
   end
 
@@ -121,7 +121,7 @@ module AppHandlers
 
     def run!
       halt(200, :message => "in run") if params['when'] == 'run'
-      false
+      data(false)
     end
 
     after_run do

--- a/test/system/server_tests.rb
+++ b/test/system/server_tests.rb
@@ -284,7 +284,7 @@ module Sanford::Server
 
       assert_equal 200, subject.code
       assert_equal 'in after run', subject.status.message
-      assert_nil subject.data
+      assert_false subject.data
     end
 
     should "allow halting in an after callback" do
@@ -293,7 +293,7 @@ module Sanford::Server
 
       assert_equal 200, subject.code
       assert_equal 'in after', subject.status.message
-      assert_nil subject.data
+      assert_false subject.data
     end
 
   end

--- a/test/unit/sanford_runner_tests.rb
+++ b/test/unit/sanford_runner_tests.rb
@@ -37,7 +37,6 @@ class Sanford::SanfordRunner
       @handler  = @runner.handler
       @response = @runner.run
     end
-    subject{ @response }
 
     should "run the handler's before callbacks" do
       assert_equal 1, @handler.first_before_call_order
@@ -54,9 +53,8 @@ class Sanford::SanfordRunner
       assert_equal 6, @handler.second_after_call_order
     end
 
-    should "build a response" do
-      assert_instance_of Sanford::Protocol::Response, subject
-      assert_equal @handler.response_data, subject.data
+    should "return its `to_response` value" do
+      assert_equal subject.to_response, @response
     end
 
   end
@@ -64,20 +62,28 @@ class Sanford::SanfordRunner
   class RunWithInitHaltTests < UnitTests
     desc "with a handler that halts on init"
     setup do
-      runner = @runner_class.new(@handler_class, :params => {
+      @runner = @runner_class.new(@handler_class, :params => {
         'halt' => 'init'
-      }).tap(&:run)
-      @handler = runner.handler
+      })
+      @handler  = @runner.handler
+      @response = @runner.run
     end
-    subject{ @handler }
+    subject{ @runner }
+
+    should "run the before and after callbacks despite the halt" do
+      assert_not_nil @handler.first_before_call_order
+      assert_not_nil @handler.second_before_call_order
+      assert_not_nil @handler.first_after_call_order
+      assert_not_nil @handler.second_after_call_order
+    end
 
     should "stop processing when the halt is called" do
-      assert_not_nil subject.first_before_call_order
-      assert_not_nil subject.second_before_call_order
-      assert_not_nil subject.init_call_order
-      assert_nil subject.run_call_order
-      assert_nil subject.first_after_call_order
-      assert_nil subject.second_after_call_order
+      assert_not_nil @handler.init_call_order
+      assert_nil @handler.run_call_order
+    end
+
+    should "return its `to_response` value despite the halt" do
+      assert_equal subject.to_response, @response
     end
 
   end
@@ -85,20 +91,28 @@ class Sanford::SanfordRunner
   class RunWithRunHaltTests < UnitTests
     desc "when run with a handler that halts on run"
     setup do
-      runner = @runner_class.new(@handler_class, :params => {
+      @runner = @runner_class.new(@handler_class, :params => {
         'halt' => 'run'
-      }).tap(&:run)
-      @handler = runner.handler
+      })
+      @handler  = @runner.handler
+      @response = @runner.run
     end
-    subject{ @handler }
+    subject{ @runner }
+
+    should "run the before and after callbacks despite the halt" do
+      assert_not_nil @handler.first_before_call_order
+      assert_not_nil @handler.second_before_call_order
+      assert_not_nil @handler.first_after_call_order
+      assert_not_nil @handler.second_after_call_order
+    end
 
     should "stop processing when the halt is called" do
-      assert_not_nil subject.first_before_call_order
-      assert_not_nil subject.second_before_call_order
-      assert_not_nil subject.init_call_order
-      assert_not_nil subject.run_call_order
-      assert_nil subject.first_after_call_order
-      assert_nil subject.second_after_call_order
+      assert_not_nil @handler.init_call_order
+      assert_not_nil @handler.run_call_order
+    end
+
+    should "return its `to_response` value despite the halt" do
+      assert_equal subject.to_response, @response
     end
 
   end
@@ -106,20 +120,31 @@ class Sanford::SanfordRunner
   class RunWithBeforeHaltTests < UnitTests
     desc "when run with a handler that halts in an after callback"
     setup do
-      runner = @runner_class.new(@handler_class, :params => {
+      @runner = @runner_class.new(@handler_class, :params => {
         'halt' => 'before'
-      }).tap(&:run)
-      @handler = runner.handler
+      })
+      @handler  = @runner.handler
+      @response = @runner.run
     end
-    subject{ @handler }
+    subject{ @runner }
 
     should "stop processing when the halt is called" do
-      assert_not_nil subject.first_before_call_order
-      assert_nil subject.second_before_call_order
-      assert_nil subject.init_call_order
-      assert_nil subject.run_call_order
-      assert_nil subject.first_after_call_order
-      assert_nil subject.second_after_call_order
+      assert_not_nil @handler.first_before_call_order
+      assert_nil @handler.second_before_call_order
+    end
+
+    should "not run the after callbacks b/c of the halt" do
+      assert_nil @handler.first_after_call_order
+      assert_nil @handler.second_after_call_order
+    end
+
+    should "not run the handler's init and run b/c of the halt" do
+      assert_nil @handler.init_call_order
+      assert_nil @handler.run_call_order
+    end
+
+    should "return its `to_response` value despite the halt" do
+      assert_equal subject.to_response, @response
     end
 
   end
@@ -127,20 +152,31 @@ class Sanford::SanfordRunner
   class RunWithAfterHaltTests < UnitTests
     desc "when run with a handler that halts in an after callback"
     setup do
-      runner = @runner_class.new(@handler_class, :params => {
+      @runner = @runner_class.new(@handler_class, :params => {
         'halt' => 'after'
-      }).tap(&:run)
-      @handler = runner.handler
+      })
+      @handler  = @runner.handler
+      @response = @runner.run
     end
-    subject{ @handler }
+    subject{ @runner }
+
+    should "run the before callback despite the halt" do
+      assert_not_nil @handler.first_before_call_order
+      assert_not_nil @handler.second_before_call_order
+    end
+
+    should "run the handler's init and run despite the halt" do
+      assert_not_nil @handler.init_call_order
+      assert_not_nil @handler.run_call_order
+    end
 
     should "stop processing when the halt is called" do
-      assert_not_nil subject.first_before_call_order
-      assert_not_nil subject.second_before_call_order
-      assert_not_nil subject.init_call_order
-      assert_not_nil subject.run_call_order
-      assert_not_nil subject.first_after_call_order
-      assert_nil subject.second_after_call_order
+      assert_not_nil @handler.first_after_call_order
+      assert_nil @handler.second_after_call_order
+    end
+
+    should "return its `to_response` value despite the halt" do
+      assert_equal subject.to_response, @response
     end
 
   end

--- a/test/unit/service_handler_tests.rb
+++ b/test/unit/service_handler_tests.rb
@@ -216,6 +216,24 @@ module Sanford::ServiceHandler
       assert_equal @runner.params, subject.instance_eval{ params }
     end
 
+    should "call to the runner for its status helper" do
+      capture_runner_meth_args_for(:status)
+      exp_args = @args
+      subject.instance_eval{ status(*exp_args) }
+
+      assert_equal exp_args, @meth_args
+      assert_nil @meth_block
+    end
+
+    should "call to the runner for its data helper" do
+      capture_runner_meth_args_for(:data)
+      exp_args = @args
+      subject.instance_eval{ data(*exp_args) }
+
+      assert_equal exp_args, @meth_args
+      assert_nil @meth_block
+    end
+
     should "call to the runner for its halt helper" do
       capture_runner_meth_args_for(:halt)
       exp_args = @args


### PR DESCRIPTION
This updates the handlers to declare their response values.  In the
handler, the return value is no longer used to affect the response.
You declare status (code/msg) and data changes via private helper
methods.  The goal here is to be able to change the response in
the callbacks.

As part of this effort, the runners have been updated to support
this behavior and to make their handling more closely match Deas'.
This involved a number of smaller changes, including:

* the sanford runner now catches halt in its before/after callbacks
* added status/data helpers to change response values
* halt and status both take similar args
* the render method auto sets the data
* the test runner no longer has a response_value reader (use the
  run method's return value instead)

@jcredding ready for review.