### PR TITLE
Update to use the new dat-tcp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gem 'rake'
 gem 'pry', "~> 0.9.0"
 
 gem 'bson_ext'
+
+gem 'dat-tcp', :path => "~/Projects/redding/gems/dat-tcp"

--- a/bench/config.sanford
+++ b/bench/config.sanford
@@ -16,9 +16,13 @@ class BenchServer
     include Sanford::ServiceHandler
 
     def run!
-      { :string => 'test', :int => 1, :float => 2.1, :boolean => true,
-        :hash => { :something => 'else' }, :array => [ 1, 2, 3 ],
-        :request_number => self.request.params['request_number']
+      { :string         => 'test',
+        :int            => 1,
+        :float          => 2.1,
+        :boolean        => true,
+        :hash           => { :something => 'else' },
+        :array          => [1, 2, 3],
+        :request_number => params['request_number']
       }
     end
 

--- a/lib/sanford/server_data.rb
+++ b/lib/sanford/server_data.rb
@@ -10,10 +10,9 @@ module Sanford
     attr_reader :name
     attr_reader :pid_file
     attr_reader :receives_keep_alive
+    attr_reader :worker_class, :worker_params
     attr_reader :verbose_logging, :logger, :template_source
     attr_reader :init_procs, :error_procs
-    attr_reader :worker_start_procs, :worker_shutdown_procs
-    attr_reader :worker_sleep_procs, :worker_wakeup_procs
     attr_reader :router, :routes
     attr_accessor :ip, :port
 
@@ -26,17 +25,15 @@ module Sanford
 
       @receives_keep_alive = !!args[:receives_keep_alive]
 
+      @worker_class  = args[:worker_class]
+      @worker_params = args[:worker_params] || {}
+
       @verbose_logging = !!args[:verbose_logging]
       @logger          = args[:logger]
       @template_source = args[:template_source]
 
       @init_procs  = args[:init_procs]  || []
       @error_procs = args[:error_procs] || []
-
-      @worker_start_procs    = args[:worker_start_procs]
-      @worker_shutdown_procs = args[:worker_shutdown_procs]
-      @worker_sleep_procs    = args[:worker_sleep_procs]
-      @worker_wakeup_procs   = args[:worker_wakeup_procs]
 
       @router = args[:router]
       @routes = build_routes(args[:routes] || [])

--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -1,12 +1,13 @@
+require 'much-plugin'
+
 module Sanford
 
   module ServiceHandler
+    include MuchPlugin
 
-    def self.included(klass)
-      klass.class_eval do
-        extend ClassMethods
-        include InstanceMethods
-      end
+    plugin_included do
+      extend ClassMethods
+      include InstanceMethods
     end
 
     module InstanceMethods

--- a/lib/sanford/worker.rb
+++ b/lib/sanford/worker.rb
@@ -1,0 +1,106 @@
+require 'much-plugin'
+require 'dat-tcp/worker'
+require 'sanford/connection_handler'
+require 'sanford/server_data'
+
+module Sanford
+
+  module Worker
+    include MuchPlugin
+
+    plugin_included do
+      include DatTCP::Worker
+      include InstanceMethods
+
+    end
+
+    module InstanceMethods
+
+      def work!(client_socket)
+        connection = Connection.new(client_socket)
+        return if sanford_keep_alive_connection?(connection)
+        Sanford::ConnectionHandler.new(params[:sanford_server_data], connection).run
+      ensure
+        connection.close rescue false
+      end
+
+      private
+
+      def sanford_keep_alive_connection?(connection)
+        params[:sanford_server_data].receives_keep_alive && connection.peek_data.empty?
+      end
+
+    end
+
+    class Connection
+      DEFAULT_TIMEOUT = 1
+
+      attr_reader :timeout
+
+      def initialize(socket)
+        @socket     = socket
+        @connection = Sanford::Protocol::Connection.new(@socket)
+        @timeout    = (ENV['SANFORD_TIMEOUT'] || DEFAULT_TIMEOUT).to_f
+      end
+
+      def write_data(data)
+        TCPCork.apply(@socket)
+        @connection.write data
+        TCPCork.remove(@socket)
+      end
+
+      def read_data;   @connection.read(@timeout); end
+      def peek_data;   @connection.peek(@timeout); end
+      def close;       @connection.close;          end
+      def close_write; @connection.close_write;    end
+    end
+
+    module TCPCork
+      # On Linux, use TCP_CORK to better control how the TCP stack
+      # packetizes our stream. This improves both latency and throughput.
+      # TCP_CORK disables Nagle's algorithm, which is ideal for sporadic
+      # traffic (like Telnet) but is less optimal for HTTP. Sanford is similar
+      # to HTTP, it doesn't receive sporadic packets, it has all its data
+      # come in at once.
+      # For more information: http://baus.net/on-tcp_cork
+
+      if RUBY_PLATFORM =~ /linux/
+        # 3 == TCP_CORK
+        def self.apply(socket)
+          socket.setsockopt(::Socket::IPPROTO_TCP, 3, true)
+        end
+
+        def self.remove(socket)
+          socket.setsockopt(::Socket::IPPROTO_TCP, 3, false)
+        end
+      else
+        def self.apply(socket);  end
+        def self.remove(socket); end
+      end
+    end
+
+    module TestHelpers
+      include MuchPlugin
+
+      plugin_included do
+        include DatTCP::Worker::TestHelpers
+        include InstanceMethods
+      end
+
+      module InstanceMethods
+
+        def test_runner(worker_class, options = nil)
+          options ||= {}
+          options[:params] = {
+            :sanford_server_data => Sanford::ServerData.new,
+          }.merge(options[:params] || {})
+          super(worker_class, options)
+        end
+
+      end
+
+    end
+
+  end
+
+end

--- a/sanford.gemspec
+++ b/sanford.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency("dat-tcp",          ["~> 0.7"])
+  gem.add_dependency("much-plugin",      ["~> 0.1"])
   gem.add_dependency("ns-options",       ["~> 1.1"])
   gem.add_dependency("sanford-protocol", ["~> 0.11"])
 

--- a/test/system/server_tests.rb
+++ b/test/system/server_tests.rb
@@ -320,7 +320,11 @@ module Sanford::Server
     setup do
       # get our current ip address, need something different than 0.0.0.0 and
       # 127.0.0.1 to bind to
-      ENV['SANFORD_IP']   = IPSocket.getaddress(Socket.gethostname)
+      ENV['SANFORD_IP'] = Socket.getaddrinfo(
+        Socket.gethostname,
+        80,
+        Socket::AF_INET
+      ).first[3]
       ENV['SANFORD_PORT'] = (AppServer.port + 1).to_s
 
       @server = AppServer.new

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -15,22 +15,20 @@ class Sanford::ServerData
 
       @route = Sanford::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
       @config_hash = {
-        :name                  => Factory.string,
-        :ip                    => Factory.string,
-        :port                  => Factory.integer,
-        :pid_file              => Factory.file_path,
-        :receives_keep_alive   => Factory.boolean,
-        :verbose_logging       => Factory.boolean,
-        :logger                => Factory.string,
-        :template_source       => Factory.string,
-        :init_procs            => Factory.integer(3).times.map{ proc{} },
-        :error_procs           => Factory.integer(3).times.map{ proc{} },
-        :worker_start_procs    => Factory.integer(3).times.map{ proc{} },
-        :worker_shutdown_procs => Factory.integer(3).times.map{ proc{} },
-        :worker_sleep_procs    => Factory.integer(3).times.map{ proc{} },
-        :worker_wakeup_procs   => Factory.integer(3).times.map{ proc{} },
-        :router                => Factory.string,
-        :routes                => [@route]
+        :name                => Factory.string,
+        :ip                  => Factory.string,
+        :port                => Factory.integer,
+        :pid_file            => Factory.file_path,
+        :receives_keep_alive => Factory.boolean,
+        :worker_class        => Class.new,
+        :worker_params       => { Factory.string => Factory.string },
+        :verbose_logging     => Factory.boolean,
+        :logger              => Factory.string,
+        :template_source     => Factory.string,
+        :init_procs          => Factory.integer(3).times.map{ proc{} },
+        :error_procs         => Factory.integer(3).times.map{ proc{} },
+        :router              => Factory.string,
+        :routes              => [@route]
       }
       @server_data = Sanford::ServerData.new(@config_hash)
     end
@@ -43,10 +41,9 @@ class Sanford::ServerData
     should have_readers :name
     should have_readers :pid_file
     should have_readers :receives_keep_alive
+    should have_readers :worker_class, :worker_params
     should have_readers :verbose_logging, :logger, :template_source
     should have_readers :init_procs, :error_procs
-    should have_readers :worker_start_procs, :worker_shutdown_procs
-    should have_readers :worker_sleep_procs, :worker_wakeup_procs
     should have_readers :router, :routes
     should have_accessors :ip, :port
 
@@ -59,17 +56,15 @@ class Sanford::ServerData
 
       assert_equal h[:receives_keep_alive], subject.receives_keep_alive
 
+      assert_equal h[:worker_class],  subject.worker_class
+      assert_equal h[:worker_params], subject.worker_params
+
       assert_equal h[:verbose_logging], subject.verbose_logging
       assert_equal h[:logger],          subject.logger
       assert_equal h[:template_source], subject.template_source
 
       assert_equal h[:init_procs],  subject.init_procs
       assert_equal h[:error_procs], subject.error_procs
-
-      assert_equal h[:worker_start_procs],    subject.worker_start_procs
-      assert_equal h[:worker_shutdown_procs], subject.worker_shutdown_procs
-      assert_equal h[:worker_sleep_procs],    subject.worker_sleep_procs
-      assert_equal h[:worker_wakeup_procs],   subject.worker_wakeup_procs
 
       assert_equal h[:router], subject.router
     end
@@ -112,6 +107,9 @@ class Sanford::ServerData
       assert_nil server_data.pid_file
 
       assert_false server_data.receives_keep_alive
+
+      assert_nil server_data.worker_class
+      assert_equal({}, server_data.worker_params)
 
       assert_false server_data.verbose_logging
       assert_nil   server_data.logger

--- a/test/unit/service_handler_tests.rb
+++ b/test/unit/service_handler_tests.rb
@@ -1,6 +1,7 @@
 require 'assert'
 require 'sanford/service_handler'
 
+require 'much-plugin'
 require 'sanford/template_engine'
 require 'sanford/template_source'
 require 'sanford/test_runner'
@@ -25,6 +26,10 @@ module Sanford::ServiceHandler
     should have_imeths :prepend_before, :prepend_after
     should have_imeths :prepend_before_init, :prepend_after_init
     should have_imeths :prepend_before_run,  :prepend_after_run
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Sanford::ServiceHandler
+    end
 
     should "return an empty array by default using `before_callbacks`" do
       assert_equal [], subject.before_callbacks

--- a/test/unit/worker_tests.rb
+++ b/test/unit/worker_tests.rb
@@ -1,0 +1,185 @@
+require 'assert'
+require 'sanford/worker'
+
+require 'dat-tcp/worker'
+require 'much-plugin'
+require 'sanford-protocol/fake_connection'
+require 'sanford/server_data'
+require 'test/support/fake_server_connection'
+
+module Sanford::Worker
+
+  class UnitTests < Assert::Context
+    include DatTCP::Worker::TestHelpers
+
+    desc "Sanford::Worker"
+    setup do
+      @worker_class = Class.new{ include Sanford::Worker }
+    end
+    subject{ @worker_class }
+
+    should "use much-plugin" do
+      assert_includes MuchPlugin, Sanford::Worker
+    end
+
+    should "be a dat-tcp worker" do
+      assert_includes DatTCP::Worker, subject
+    end
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @socket      = Factory.binary
+      @server_data = Sanford::ServerData.new
+
+      @connection = FakeServerConnection.new
+      Assert.stub(Connection, :new).with(@socket){ @connection }
+
+      @ch_spy = nil
+      Assert.stub(Sanford::ConnectionHandler, :new) do |*args|
+        @ch_spy = ConnectionHandlerSpy.new(*args)
+      end
+
+      @worker_params = {
+        :sanford_server_data => @server_data
+      }
+      @runner = test_runner(@worker_class, :params => @worker_params)
+    end
+    subject{ @runner }
+
+    should "build and run a connection handler when it processes a socket" do
+      Assert.stub(@server_data, :receives_keep_alive){ false }
+      @connection.read_data = Factory.string
+      subject.work(@socket)
+
+      assert_not_nil @ch_spy
+      assert_equal @server_data, @ch_spy.server_data
+      assert_equal @connection,  @ch_spy.connection
+      assert_true @ch_spy.run_called
+    end
+
+    should "not run a connection handler when it processes a " \
+           "keep-alive connection and its configured to expect them" do
+      Assert.stub(@server_data, :receives_keep_alive){ true }
+      @connection.read_data = nil # nothing to read makes it a keep-alive
+      subject.work(@socket)
+
+      assert_nil @ch_spy
+    end
+
+    should "run a connection handler when it processes a " \
+           "keep-alive connection and its not configured to expect them" do
+      Assert.stub(@server_data, :receives_keep_alive){ false }
+      @connection.read_data = nil # nothing to read makes it a keep-alive
+      subject.work(@socket)
+
+      assert_not_nil @ch_spy
+      assert_equal @server_data, @ch_spy.server_data
+      assert_equal @connection,  @ch_spy.connection
+      assert_true @ch_spy.run_called
+    end
+
+  end
+
+  class ConnectionTests < UnitTests
+    desc "Connection"
+    setup do
+      fake_socket = Factory.string
+      @protocol_conn = Sanford::Protocol::FakeConnection.new(Factory.binary)
+      Assert.stub(Sanford::Protocol::Connection, :new).with(fake_socket) do
+        @protocol_conn
+      end
+      @connection = Connection.new(fake_socket)
+    end
+    subject{ @connection }
+
+    should have_imeths :read_data, :write_data, :peek_data
+    should have_imeths :close_write
+
+    should "default its timeout" do
+      assert_equal 1.0, subject.timeout
+    end
+
+    should "allowing reading from the protocol connection" do
+      result = subject.read_data
+      assert_equal @protocol_conn.read_data, result
+      assert_equal @protocol_conn.read_timeout, subject.timeout
+    end
+
+    should "allowing writing to the protocol connection" do
+      data = Factory.binary
+      subject.write_data(data)
+      assert_equal @protocol_conn.write_data, data
+    end
+
+    should "allowing peeking from the protocol connection" do
+      result = subject.peek_data
+      assert_equal @protocol_conn.peek_data, result
+      assert_equal @protocol_conn.peek_timeout, subject.timeout
+    end
+
+    should "allow closing the write stream on the protocol connection" do
+      assert_false @protocol_conn.closed_write
+      subject.close_write
+      assert_true @protocol_conn.closed_write
+    end
+
+  end
+
+  class TCPCorkTests < UnitTests
+    desc "TCPCork"
+    subject{ TCPCork }
+
+    should have_imeths :apply, :remove
+
+  end
+
+  class TestHelpersTests < UnitTests
+    desc "TestHelpers"
+    setup do
+      @context_class = Class.new{ include TestHelpers }
+      @context = @context_class.new
+    end
+    subject{ @context }
+
+    should have_imeths :test_runner
+
+    should "mixin dat-tcp's worker test helpers" do
+      assert_includes DatTCP::Worker::TestHelpers, @context_class
+    end
+
+    should "super worker params needed to run a sanford worker" do
+      runner = @context.test_runner(@worker_class)
+      worker_params = runner.dwp_runner.worker_params
+
+      assert_instance_of Sanford::ServerData, worker_params[:sanford_server_data]
+    end
+
+    should "allow providing custom worker params for running a sanford worker" do
+      @params = {
+        :sanford_server_data => Factory.string,
+      }
+      runner = @context.test_runner(@worker_class, :params => @params)
+
+      assert_equal @params, runner.dwp_runner.worker_params
+    end
+
+  end
+
+  class ConnectionHandlerSpy
+    attr_reader :server_data, :connection, :run_called
+
+    def initialize(server_data, connection)
+      @server_data = server_data
+      @connection  = connection
+      @run_called  = false
+    end
+
+    def run
+      @run_called = true
+    end
+  end
+
+end


### PR DESCRIPTION
This updates sanford to use the new dat-tcp. dat-tcp's interface
has changed but functionally it works the same as it previously
did. This also brings in much-plugin in and uses it for its
server and service handler mixins. This ensures the mixin logic is
only included once.

A server can now be configured with a worker class instead of
worker procs. This is because dat-tcp now requires a worker class
when its initialized. A block is no longer part of dat-tcp's
interface. The logic for processing a work item (a client socket
for sanford) is now part of the worker class that is passed in.
Worker callbacks should now be added to the worker class thats
configured.

As part of this change, sanford now also provides a `Worker` mixin
which as mentioned before, contains the logic for processing a
client socket. This mixin is required for any worker class that is
configured on a server.

This also updates styles and conventions to our latest standards
throughout and updates the system tests to do a better job of
looking for an non-localhost IPv4 address. The previous code could
return an IPv6 address.

@kellyredding - Ready for review.