### PR TITLE
Pass num workers, logger and shutdown timeout to dat-tcp

### DIFF
--- a/bench/config.sanford
+++ b/bench/config.sanford
@@ -1,3 +1,6 @@
+LOGGER = Logger.new(STDOUT)
+LOGGER.datetime_format = "" # turn off the datetime in the logs
+
 class BenchServer
   include Sanford::Server
 
@@ -5,7 +8,7 @@ class BenchServer
   port     59284
   pid_file File.expand_path("../../tmp/bench_server.pid", __FILE__)
 
-  logger          Logger.new(STDOUT)
+  logger          LOGGER
   verbose_logging false
 
   router do

--- a/lib/sanford/connection_handler.rb
+++ b/lib/sanford/connection_handler.rb
@@ -27,7 +27,6 @@ module Sanford
       end
       processed_service.time_taken = RoundedTime.new(benchmark.real)
       self.log_complete(processed_service)
-      self.raise_if_debugging!(processed_service.exception)
       processed_service
     end
 
@@ -80,10 +79,6 @@ module Sanford
       processed_service.exception = error_handler.exception
       self.log_exception(processed_service.exception)
       processed_service
-    end
-
-    def raise_if_debugging!(exception)
-      raise exception if exception && ENV['SANFORD_DEBUG']
     end
 
     def log_received

--- a/lib/sanford/server_data.rb
+++ b/lib/sanford/server_data.rb
@@ -10,8 +10,9 @@ module Sanford
     attr_reader :name
     attr_reader :pid_file
     attr_reader :receives_keep_alive
-    attr_reader :worker_class, :worker_params
-    attr_reader :verbose_logging, :logger, :template_source
+    attr_reader :worker_class, :worker_params, :num_workers
+    attr_reader :debug, :logger, :dtcp_logger, :verbose_logging
+    attr_reader :template_source, :shutdown_timeout
     attr_reader :init_procs, :error_procs
     attr_reader :router, :routes
     attr_accessor :ip, :port
@@ -27,10 +28,16 @@ module Sanford
 
       @worker_class  = args[:worker_class]
       @worker_params = args[:worker_params] || {}
+      @num_workers   = args[:num_workers]
 
-      @verbose_logging = !!args[:verbose_logging]
+      @debug           = !ENV['SANFORD_DEBUG'].to_s.empty?
       @logger          = args[:logger]
+      @dtcp_logger     = @logger if @debug
+      @verbose_logging = !!args[:verbose_logging]
+
       @template_source = args[:template_source]
+
+      @shutdown_timeout = args[:shutdown_timeout]
 
       @init_procs  = args[:init_procs]  || []
       @error_procs = args[:error_procs] || []

--- a/test/support/app_server.rb
+++ b/test/support/app_server.rb
@@ -6,6 +6,9 @@ if !defined?(ROOT_PATH)
   ROOT_PATH = Pathname.new(File.expand_path('../../..', __FILE__))
 end
 
+LOGGER = Logger.new(ROOT_PATH.join('log/app_server.log').to_s)
+LOGGER.datetime_format = "" # turn off the datetime in the logs
+
 class AppERBEngine < Sanford::TemplateEngine
   RenderScope = Struct.new(:view)
 
@@ -26,7 +29,7 @@ class AppServer
 
   receives_keep_alive true
 
-  logger Logger.new(ROOT_PATH.join('log/app_server.log').to_s)
+  logger LOGGER
   verbose_logging true
 
   router do

--- a/test/unit/connection_handler_tests.rb
+++ b/test/unit/connection_handler_tests.rb
@@ -142,22 +142,6 @@ class Sanford::ConnectionHandler
 
   end
 
-  class RunWithExceptionWhileDebuggingTests < InitTests
-    desc "and run with a route that throws an exception in debug mode"
-    setup do
-      ENV['SANFORD_DEBUG'] = '1'
-      Assert.stub(@route, :run){ raise @exception }
-    end
-    teardown do
-      ENV.delete('SANFORD_DEBUG')
-    end
-
-    should "raise the exception" do
-      assert_raises(@exception.class){ @connection_handler.run }
-    end
-
-  end
-
   class RunWithVerboseLoggingTests < UnitTests
     desc "run with verbose logging"
     setup do

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -22,9 +22,11 @@ class Sanford::ServerData
         :receives_keep_alive => Factory.boolean,
         :worker_class        => Class.new,
         :worker_params       => { Factory.string => Factory.string },
+        :num_workers         => Factory.integer,
         :verbose_logging     => Factory.boolean,
         :logger              => Factory.string,
         :template_source     => Factory.string,
+        :shutdown_timeout    => Factory.integer,
         :init_procs          => Factory.integer(3).times.map{ proc{} },
         :error_procs         => Factory.integer(3).times.map{ proc{} },
         :router              => Factory.string,
@@ -41,8 +43,9 @@ class Sanford::ServerData
     should have_readers :name
     should have_readers :pid_file
     should have_readers :receives_keep_alive
-    should have_readers :worker_class, :worker_params
-    should have_readers :verbose_logging, :logger, :template_source
+    should have_readers :worker_class, :worker_params, :num_workers
+    should have_readers :debug, :logger, :dtcp_logger, :verbose_logging
+    should have_readers :template_source, :shutdown_timeout
     should have_readers :init_procs, :error_procs
     should have_readers :router, :routes
     should have_accessors :ip, :port
@@ -58,10 +61,14 @@ class Sanford::ServerData
 
       assert_equal h[:worker_class],  subject.worker_class
       assert_equal h[:worker_params], subject.worker_params
+      assert_equal h[:num_workers],   subject.num_workers
 
       assert_equal h[:verbose_logging], subject.verbose_logging
       assert_equal h[:logger],          subject.logger
+
       assert_equal h[:template_source], subject.template_source
+
+      assert_equal h[:shutdown_timeout], subject.shutdown_timeout
 
       assert_equal h[:init_procs],  subject.init_procs
       assert_equal h[:error_procs], subject.error_procs
@@ -110,10 +117,14 @@ class Sanford::ServerData
 
       assert_nil server_data.worker_class
       assert_equal({}, server_data.worker_params)
+      assert_nil server_data.num_workers
 
       assert_false server_data.verbose_logging
       assert_nil   server_data.logger
-      assert_nil   server_data.template_source
+
+      assert_nil server_data.template_source
+
+      assert_nil server_data.shutdown_timeout
 
       assert_equal [], server_data.init_procs
       assert_equal [], server_data.error_procs


### PR DESCRIPTION
This updates sanford to pass num workers, logger and shutdown
timeout to dat-tcp. The logger is only passed as part of sanford's
updated debug mode which allows extra logging by dat-tcp. As part
of this a sanford server can now be configured with a number of
workers and a shutdown timeout. This is consistent with qs,
formalizes sanfords debug mode and makes it more flexible.

A server can now be configured with a num workers and a shutdown
timeout. These values will be passed onto dat-tcp and will
determine how many workers are initially spawned and how long
it lets its shutdown logic run. Qs allows configuring these so
this makes sanford consistent with it.

The server data now also has a debug flag that is set by the env
var `SANFORD_DEBUG`. When this is set, the sanford logger will be
passed to dat-tcp. This shouldn't be set in a live environment
because dat-tcp does a lot of extra logging that will slow down
sanford handling connections.

This also removes the connection handler raising an exception if
the `SANFORD_DEBUG` flag is set. This is a development feature that
was used when initially developing sanford logic. It was never
intended to be a feature outside of the sanford repo and test suite.
This removes it so its no longer tied to the `SANFORD_DEBUG` env
var. If we need it again when updating sanford we can figure a way
to add the feature back so that it is only part of the test suite.

@kellyredding - Ready for review.