### PR TITLE
add equality operators for template source/engine

### DIFF
--- a/lib/sanford/template_engine.rb
+++ b/lib/sanford/template_engine.rb
@@ -17,6 +17,15 @@ module Sanford
       raise NotImplementedError
     end
 
+    def ==(other_engine)
+      if other_engine.kind_of?(TemplateEngine)
+        self.source_path == other_engine.source_path &&
+        self.opts        == other_engine.opts
+      else
+        super
+      end
+    end
+
   end
 
   class NullTemplateEngine < TemplateEngine

--- a/lib/sanford/template_source.rb
+++ b/lib/sanford/template_source.rb
@@ -42,6 +42,15 @@ module Sanford
       engine.render(template_path, service_handler, locals)
     end
 
+    def ==(other_template_source)
+      if other_template_source.kind_of?(TemplateSource)
+        self.path    == other_template_source.path &&
+        self.engines == other_template_source.engines
+      else
+        super
+      end
+    end
+
     private
 
     def get_template_ext(template_path)


### PR DESCRIPTION
This is so we can test that equality in apps that use/configure
template sources and engines.  This came up when trying to test
an app that uses Sanford.

@jcredding ready for review.  Couldn't resist even though I didn't want to bother with this right now. :smile: 