### PR TITLE
Pass registered engine ext to engine as option

### DIFF
--- a/lib/sanford/template_engine.rb
+++ b/lib/sanford/template_engine.rb
@@ -13,7 +13,7 @@ module Sanford
       @logger = @opts['logger'] || Sanford::NullLogger.new
     end
 
-    def render(path, service_handler, locals)
+    def render(name, service_handler, locals)
       raise NotImplementedError
     end
 
@@ -30,8 +30,8 @@ module Sanford
 
   class NullTemplateEngine < TemplateEngine
 
-    def render(path, service_handler, locals)
-      template_file = self.source_path.join(path).to_s
+    def render(name, service_handler, locals)
+      template_file = self.source_path.join(name).to_s
       unless File.exists?(template_file)
         raise ArgumentError, "template file `#{template_file}` does not exist"
       end

--- a/lib/sanford/template_source.rb
+++ b/lib/sanford/template_source.rb
@@ -26,6 +26,7 @@ module Sanford
                                         " engine extension."
       end
       engine_opts = @default_opts.merge(registered_opts || {})
+      engine_opts['ext'] = input_ext.to_s
       @engines[input_ext.to_s] = engine_class.new(engine_opts)
     end
 
@@ -37,9 +38,9 @@ module Sanford
       self.engine_for?(get_template_ext(template_name))
     end
 
-    def render(template_path, service_handler, locals)
-      engine = @engines[get_template_ext(template_path)]
-      engine.render(template_path, service_handler, locals)
+    def render(template_name, service_handler, locals)
+      engine = @engines[get_template_ext(template_name)]
+      engine.render(template_name, service_handler, locals)
     end
 
     def ==(other_template_source)
@@ -53,14 +54,14 @@ module Sanford
 
     private
 
-    def get_template_ext(template_path)
-      files = Dir.glob("#{File.join(@path, template_path.to_s)}.*")
+    def get_template_ext(template_name)
+      files = Dir.glob("#{File.join(@path, template_name.to_s)}.*")
       files = files.reject{ |p| !@engines.keys.include?(parse_ext(p)) }
       parse_ext(files.first.to_s || '')
     end
 
-    def parse_ext(template_path)
-      File.extname(template_path)[1..-1]
+    def parse_ext(template_name)
+      File.extname(template_name)[1..-1]
     end
 
   end

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -48,34 +48,36 @@ class Sanford::TemplateSource
     end
 
     should "register with default options" do
-      subject.engine 'test', @test_engine
-      exp_opts = {
-        'source_path' => subject.path,
-        'logger'      => @logger
-      }
-      assert_equal exp_opts, subject.engines['test'].opts
-
-      source = Sanford::TemplateSource.new(@source_path)
-      source.engine 'test', @test_engine
-      assert_kind_of Sanford::NullLogger, source.engines['test'].opts['logger']
-
-      subject.engine 'test', @test_engine, 'an' => 'opt'
+      engine_ext = Factory.string
+      subject.engine engine_ext, @test_engine
       exp_opts = {
         'source_path' => subject.path,
         'logger'      => @logger,
-        'an'          => 'opt'
+        'ext'         => engine_ext
       }
-      assert_equal exp_opts, subject.engines['test'].opts
+      assert_equal exp_opts, subject.engines[engine_ext].opts
 
-      subject.engine('test', @test_engine, {
-        'source_path' => 'something',
-        'logger'      => 'another'
-      })
+      source = Sanford::TemplateSource.new(@source_path)
+      source.engine engine_ext, @test_engine
+      assert_kind_of Sanford::NullLogger, source.engines[engine_ext].opts['logger']
+
+      custom_opts = { Factory.string => Factory.string }
+      subject.engine engine_ext, @test_engine, custom_opts
       exp_opts = {
-        'source_path' => 'something',
-        'logger'      => 'another'
+        'source_path' => subject.path,
+        'logger'      => @logger,
+        'ext'         => engine_ext
+      }.merge(custom_opts)
+      assert_equal exp_opts, subject.engines[engine_ext].opts
+
+      custom_opts = {
+        'source_path' => Factory.string,
+        'logger'      => Factory.string,
+        'ext'         => Factory.string
       }
-      assert_equal exp_opts, subject.engines['test'].opts
+      subject.engine(engine_ext, @test_engine, custom_opts)
+      exp_opts = custom_opts.merge('ext' => engine_ext)
+      assert_equal exp_opts, subject.engines[engine_ext].opts
     end
 
     should "complain if registering a disallowed temp" do


### PR DESCRIPTION
This updates template sources to pass the extension that was used
to register an engine to the engine as an option. The goal is to
allow the engine to choose templates that match the extension that
was used when configuring the extension. This is also part of
fixing an issue with the engines not knowing which template file
to pick because they no longer hard-code an extension that the
templates have to use.

The template source now always sets an ext option and passes it
to the engines when they are registered. The ext will always be
set and can't be different from how the engine is registered. It
would be non-sensical to register with one engine ext and pass a
different engine ext as an option. Sanford would either not use
the registered engine to render the template or the template
engine wouldn't find the file. Either case wouldn't produce the
desired result.

Specifically, this is part of fixing an issue with the nm template
engine no longer forcing templates extension to be `nm` (see
redding/nm#16). By not expecting an extension, the nm engine can't
pick the correct file as the template if there are multiple files
with the same name except for their extensions. For example, a
common pattern is to name a handler file and the template the same
only the handler will have `.rb` for its extension and the template
would use `.nm`. In this scenario, it's possible for the nm engine
to try and use the ruby file as its template. Nm is being updated
to use a custom extension (the one sanford will now pass to the
engine) to address this issue (redding/nm#17).

Finally, this also renames "path" variables to "name" in the
template source and engine. The variables are expected to be names
and not full paths. This doesn't change any functionality it just
clarifies the variable names.

@kellyredding - Ready for review.