### PR TITLE
templates: cache null template engines on known null extensions

### DIFF
--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -45,6 +45,9 @@ class Sanford::TemplateSource
       assert_kind_of Sanford::NullTemplateEngine, subject.engines['test']
       subject.engine 'test', @test_engine
       assert_kind_of @test_engine, subject.engines['test']
+
+      assert_true  subject.engine_for?('test')
+      assert_false subject.engine_for?(Factory.string)
     end
 
     should "register with default options" do
@@ -56,6 +59,7 @@ class Sanford::TemplateSource
         'ext'         => engine_ext
       }
       assert_equal exp_opts, subject.engines[engine_ext].opts
+      assert_true subject.engine_for?(engine_ext)
 
       source = Sanford::TemplateSource.new(@source_path)
       source.engine engine_ext, @test_engine
@@ -69,6 +73,7 @@ class Sanford::TemplateSource
         'ext'         => engine_ext
       }.merge(custom_opts)
       assert_equal exp_opts, subject.engines[engine_ext].opts
+      assert_true subject.engine_for?(engine_ext)
 
       custom_opts = {
         'source_path' => Factory.string,
@@ -78,6 +83,7 @@ class Sanford::TemplateSource
       subject.engine(engine_ext, @test_engine, custom_opts)
       exp_opts = custom_opts.merge('ext' => engine_ext)
       assert_equal exp_opts, subject.engines[engine_ext].opts
+      assert_true subject.engine_for?(engine_ext)
     end
 
     should "complain if registering a disallowed temp" do


### PR DESCRIPTION
This minor optimization will now cache null template extensions.
The idea is to not repeatedly call the engine cache default block
for known null extensions.

To make this possible, I had to update the logic for determining
if we have a registered engine.  We now store a separate list of
registered extensions. This implementation is nice b/c it decouples
the engine cache from defining whether an engine is registered or not.

Note: this optimization matches Deas' handling of its null template
engines.  See redding/deas PR 210 for details.

See redding/deas#210 for reference.

@jcredding ready for review.