### PR TITLE
remove ns-options dependency

### DIFF
--- a/lib/sanford/router.rb
+++ b/lib/sanford/router.rb
@@ -24,6 +24,11 @@ module Sanford
       @routes.push(Sanford::Route.new(name, handler_name))
     end
 
+    def validate!
+      self.routes.each(&:validate!)
+      true
+    end
+
     def inspect
       reference = '0x0%x' % (self.object_id << 1)
       "#<#{self.class}:#{reference} " \

--- a/lib/sanford/server_data.rb
+++ b/lib/sanford/server_data.rb
@@ -7,15 +7,12 @@ module Sanford
     # options one time here and memoize their values. This way, we don't pay the
     # NsOptions overhead when reading them while handling a request.
 
-    attr_reader :name
-    attr_reader :pid_file
-    attr_reader :receives_keep_alive
-    attr_reader :worker_class, :worker_params, :num_workers
-    attr_reader :debug, :logger, :dtcp_logger, :verbose_logging
-    attr_reader :template_source, :shutdown_timeout
-    attr_reader :init_procs, :error_procs
-    attr_reader :router, :routes
     attr_accessor :ip, :port
+    attr_reader :name, :pid_file, :shutdown_timeout
+    attr_reader :worker_class, :worker_params, :num_workers
+    attr_reader :init_procs, :error_procs, :template_source, :logger, :router
+    attr_reader :receives_keep_alive, :verbose_logging
+    attr_reader :debug, :dtcp_logger, :routes
 
     def initialize(args = nil)
       args ||= {}
@@ -24,26 +21,23 @@ module Sanford
       @port     = !(v = ENV['SANFORD_PORT'].to_s).empty? ? v.to_i : args[:port]
       @pid_file = args[:pid_file]
 
-      @receives_keep_alive = !!args[:receives_keep_alive]
-
-      @worker_class  = args[:worker_class]
-      @worker_params = args[:worker_params] || {}
-      @num_workers   = args[:num_workers]
-
-      @debug           = !ENV['SANFORD_DEBUG'].to_s.empty?
-      @logger          = args[:logger]
-      @dtcp_logger     = @logger if @debug
-      @verbose_logging = !!args[:verbose_logging]
-
-      @template_source = args[:template_source]
-
       @shutdown_timeout = args[:shutdown_timeout]
 
-      @init_procs  = args[:init_procs]  || []
-      @error_procs = args[:error_procs] || []
+      @worker_class    = args[:worker_class]
+      @worker_params   = args[:worker_params] || {}
+      @num_workers     = args[:num_workers]
+      @init_procs      = args[:init_procs]  || []
+      @error_procs     = args[:error_procs] || []
+      @template_source = args[:template_source]
+      @logger          = args[:logger]
+      @router          = args[:router]
 
-      @router = args[:router]
-      @routes = build_routes(args[:routes] || [])
+      @receives_keep_alive = !!args[:receives_keep_alive]
+      @verbose_logging     = !!args[:verbose_logging]
+
+      @debug       = !ENV['SANFORD_DEBUG'].to_s.empty?
+      @dtcp_logger = @logger if @debug
+      @routes      = build_routes(args[:routes] || [])
     end
 
     def route_for(name)

--- a/lib/sanford/template_source.rb
+++ b/lib/sanford/template_source.rb
@@ -69,8 +69,8 @@ module Sanford
 
   class NullTemplateSource < TemplateSource
 
-    def initialize
-      super('')
+    def initialize(root = nil)
+      super(root || '')
     end
 
   end

--- a/sanford.gemspec
+++ b/sanford.gemspec
@@ -18,10 +18,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("assert", ["~> 2.15.0"])
+  gem.add_development_dependency("assert", ["~> 2.16.1"])
 
   gem.add_dependency("dat-tcp",          ["~> 0.8.0"])
-  gem.add_dependency("much-plugin",      ["~> 0.1.0"])
-  gem.add_dependency("ns-options",       ["~> 1.1.6"])
+  gem.add_dependency("much-plugin",      ["~> 0.1.1"])
   gem.add_dependency("sanford-protocol", ["~> 0.11.0"])
 end

--- a/test/system/service_handler_tests.rb
+++ b/test/system/service_handler_tests.rb
@@ -62,8 +62,8 @@ module Sanford::ServiceHandler
     setup do
       @params = { 'message' => Factory.text }
       @runner = test_runner(AppHandlers::Template, {
-        :params => @params,
-        :template_source => AppServer.configuration.template_source
+        :params          => @params,
+        :template_source => AppServer.config.template_source
       })
       @handler = @runner.handler
     end

--- a/test/unit/router_tests.rb
+++ b/test/unit/router_tests.rb
@@ -8,12 +8,21 @@ class Sanford::Router
   class UnitTests < Assert::Context
     desc "Sanford::Router"
     setup do
-      @router = Sanford::Router.new
+      @router_class = Sanford::Router
+    end
+    subject{ @router_class }
+
+  end
+
+  class InitTests < UnitTests
+    desc "when init"
+    setup do
+      @router = @router_class.new
     end
     subject{ @router }
 
     should have_readers :routes
-    should have_imeths :service_handler_ns, :service
+    should have_imeths :service_handler_ns, :service, :validate!
 
     should "build an empty array for its routes by default" do
       assert_equal [], subject.routes
@@ -53,6 +62,13 @@ class Sanford::Router
       assert_equal expected, route.handler_class_name
     end
 
+    should "validate each route when validating" do
+      subject.service(Factory.string, TestHandler.to_s)
+      subject.routes.each{ |route| assert_nil route.handler_class }
+      subject.validate!
+      subject.routes.each{ |route| assert_not_nil route.handler_class }
+    end
+
     should "know its custom inspect" do
       reference = '0x0%x' % (subject.object_id << 1)
       expected = "#<#{subject.class}:#{reference} " \
@@ -61,5 +77,7 @@ class Sanford::Router
     end
 
   end
+
+  TestHandler = Class.new
 
 end

--- a/test/unit/server_data_tests.rb
+++ b/test/unit/server_data_tests.rb
@@ -8,10 +8,12 @@ class Sanford::ServerData
   class UnitTests < Assert::Context
     desc "Sanford::ServerData"
     setup do
-      @orig_ip_env_var   = ENV['SANFORD_IP']
-      @orig_port_env_var = ENV['SANFORD_PORT']
+      @orig_ip_env_var    = ENV['SANFORD_IP']
+      @orig_port_env_var  = ENV['SANFORD_PORT']
+      @orig_debug_env_var = ENV['SANFORD_DEBUG']
       ENV.delete('SANFORD_IP')
       ENV.delete('SANFORD_PORT')
+      ENV.delete('SANFORD_DEBUG')
 
       @route = Sanford::Route.new(Factory.string, TestHandler.to_s).tap(&:validate!)
       @config_hash = {
@@ -19,61 +21,62 @@ class Sanford::ServerData
         :ip                  => Factory.string,
         :port                => Factory.integer,
         :pid_file            => Factory.file_path,
-        :receives_keep_alive => Factory.boolean,
+        :shutdown_timeout    => Factory.integer,
         :worker_class        => Class.new,
         :worker_params       => { Factory.string => Factory.string },
         :num_workers         => Factory.integer,
-        :verbose_logging     => Factory.boolean,
-        :logger              => Factory.string,
-        :template_source     => Factory.string,
-        :shutdown_timeout    => Factory.integer,
         :init_procs          => Factory.integer(3).times.map{ proc{} },
         :error_procs         => Factory.integer(3).times.map{ proc{} },
+        :template_source     => Factory.string,
+        :logger              => Factory.string,
         :router              => Factory.string,
+        :receives_keep_alive => Factory.boolean,
+        :verbose_logging     => Factory.boolean,
         :routes              => [@route]
       }
       @server_data = Sanford::ServerData.new(@config_hash)
     end
     teardown do
-      ENV['SANFORD_IP']   = @orig_ip_env_var
-      ENV['SANFORD_PORT'] = @orig_port_env_var
+      ENV['SANFORD_IP']    = @orig_ip_env_var
+      ENV['SANFORD_PORT']  = @orig_port_env_var
+      ENV['SANFORD_DEBUG'] = @orig_debug_env_var
     end
     subject{ @server_data }
 
-    should have_readers :name
-    should have_readers :pid_file
-    should have_readers :receives_keep_alive
-    should have_readers :worker_class, :worker_params, :num_workers
-    should have_readers :debug, :logger, :dtcp_logger, :verbose_logging
-    should have_readers :template_source, :shutdown_timeout
-    should have_readers :init_procs, :error_procs
-    should have_readers :router, :routes
     should have_accessors :ip, :port
+    should have_readers :name, :pid_file, :shutdown_timeout
+    should have_readers :worker_class, :worker_params, :num_workers
+    should have_readers :init_procs, :error_procs, :template_source, :logger, :router
+    should have_readers :receives_keep_alive, :verbose_logging
+    should have_readers :debug, :dtcp_logger, :routes
+    should have_imeths :route_for
 
-    should "know its attributes" do
+    should "know its attrs" do
       h = @config_hash
       assert_equal h[:name],     subject.name
       assert_equal h[:ip],       subject.ip
       assert_equal h[:port],     subject.port
       assert_equal h[:pid_file], subject.pid_file
 
-      assert_equal h[:receives_keep_alive], subject.receives_keep_alive
-
-      assert_equal h[:worker_class],  subject.worker_class
-      assert_equal h[:worker_params], subject.worker_params
-      assert_equal h[:num_workers],   subject.num_workers
-
-      assert_equal h[:verbose_logging], subject.verbose_logging
-      assert_equal h[:logger],          subject.logger
-
-      assert_equal h[:template_source], subject.template_source
-
       assert_equal h[:shutdown_timeout], subject.shutdown_timeout
 
-      assert_equal h[:init_procs],  subject.init_procs
-      assert_equal h[:error_procs], subject.error_procs
+      assert_equal h[:worker_class],    subject.worker_class
+      assert_equal h[:worker_params],   subject.worker_params
+      assert_equal h[:num_workers],     subject.num_workers
+      assert_equal h[:init_procs],      subject.init_procs
+      assert_equal h[:error_procs],     subject.error_procs
+      assert_equal h[:template_source], subject.template_source
+      assert_equal h[:logger],          subject.logger
+      assert_equal h[:router],          subject.router
 
-      assert_equal h[:router], subject.router
+      assert_equal h[:receives_keep_alive], subject.receives_keep_alive
+      assert_equal h[:verbose_logging],     subject.verbose_logging
+
+      assert_false subject.debug
+      assert_nil   subject.dtcp_logger
+
+      exp = { @route.name => @route }
+      assert_equal exp, subject.routes
     end
 
     should "use ip and port env vars if they are set" do
@@ -90,9 +93,11 @@ class Sanford::ServerData
       assert_equal @config_hash[:port], server_data.port
     end
 
-    should "build a routes lookup hash" do
-      expected = { @route.name => @route }
-      assert_equal expected, subject.routes
+    should "set a dctp logger if in debug mode" do
+      ENV['SANFORD_DEBUG'] = Factory.string
+      server_data = Sanford::ServerData.new(@config_hash)
+      assert_true server_data.debug
+      assert_equal server_data.logger, server_data.dtcp_logger
     end
 
     should "allow lookup a route using `route_for`" do
@@ -106,30 +111,31 @@ class Sanford::ServerData
       end
     end
 
-    should "default its attributes when they aren't provided" do
+    should "default its attrs when they aren't provided" do
       server_data = Sanford::ServerData.new
       assert_nil server_data.name
       assert_nil server_data.ip
       assert_nil server_data.port
       assert_nil server_data.pid_file
-
-      assert_false server_data.receives_keep_alive
+      assert_nil server_data.shutdown_timeout
 
       assert_nil server_data.worker_class
       assert_equal({}, server_data.worker_params)
       assert_nil server_data.num_workers
 
-      assert_false server_data.verbose_logging
-      assert_nil   server_data.logger
-
-      assert_nil server_data.template_source
-
-      assert_nil server_data.shutdown_timeout
-
       assert_equal [], server_data.init_procs
       assert_equal [], server_data.error_procs
 
-      assert_nil       server_data.router
+      assert_nil server_data.template_source
+      assert_nil server_data.logger
+      assert_nil server_data.router
+
+      assert_false server_data.receives_keep_alive
+      assert_false server_data.verbose_logging
+
+      assert_false server_data.debug
+      assert_nil server_data.dtcp_logger
+
       assert_equal({}, server_data.routes)
     end
 

--- a/test/unit/template_source_tests.rb
+++ b/test/unit/template_source_tests.rb
@@ -141,6 +141,12 @@ class Sanford::TemplateSource
       assert_equal '', subject.path
     end
 
+    should "optionally take a root path" do
+      exp = Factory.path
+      source = Sanford::NullTemplateSource.new(exp)
+      assert_equal exp, source.path
+    end
+
   end
 
   class TestEngine < Sanford::TemplateEngine


### PR DESCRIPTION
We are moving away from using ns-options as a dependency b/c it
has performance issues when accessing options and on top of that
its API hasn't proven to be especially useful over a struct-like
class.

This removes ns-options and reworks the server, its config and the
server data to support the non-ns-options config implementation.
The config is now a simple struct-like class with a bunch of
accessors for its attrs.  The server class methods now implement
the ns-options-like DSL api for each of their attrs for backwards
compatibility.

In addition, I did a number of smaller changes/cleanups, including
some thing that aren't backwards compatible:

* switched to calling the config "config" (more succinct than prev
  with no loss of clarity).
* you can no longer set config values to procs (for lazy eval'ing).
  I chose to not keep this behavior.
* I dropped the `to_hash` logic and switched to just manually
  building the server data.  I'm just trying to simplify the API
  here and blindly using the config's hash kinda hides what values
  are being set.
* I reworked the order of config/server/server-data settings to
  try and get everything to match.  This is just to be consistent
  and help keep things organized/readable.  I tried to follow the
  order Deas uses as much as possible.
* I did a bunch of test cleanups to not only test the new logic
  but use modern conventions like Factory values and also test
  things more thoroughly.
* updated to the NullTemplateSource to take an optionall root path.
  This matches Deas' implementation and also allows default template
  source to be based on the pwd (like Deas' is).  This is a more
  usable default.
* updated the router to abstract its `validate!` logic to match
  Deas' implementation.
* updated the assert dependency to get access to the latest stuff.

Overall there are some backwards incompatible changes but the basic
behavior isn't changing.  Most of the diff is just reordering things
and reworking to remove ns-options logic where needed.

@jcredding ready for review.