### PR TITLE
cleanup server/server-data implementation to better match Deas/Qs

### DIFF
--- a/lib/sanford/server_data.rb
+++ b/lib/sanford/server_data.rb
@@ -2,15 +2,15 @@ module Sanford
 
   class ServerData
 
-    # The server uses this to "compile" its configuration for speed. NsOptions
-    # is relatively slow everytime an option is read. To avoid this, we read the
-    # options one time here and memoize their values. This way, we don't pay the
-    # NsOptions overhead when reading them while handling a request.
+    # The server uses this to "compile" the common configuration data used
+    # by the server instances, error handlers and routes. The goal here is
+    # to provide these with a simplified interface with the minimal data needed
+    # and to decouple the configuration from each thing that needs its data.
 
     attr_accessor :ip, :port
     attr_reader :name, :pid_file, :shutdown_timeout
     attr_reader :worker_class, :worker_params, :num_workers
-    attr_reader :init_procs, :error_procs, :template_source, :logger, :router
+    attr_reader :error_procs, :template_source, :logger, :router
     attr_reader :receives_keep_alive, :verbose_logging
     attr_reader :debug, :dtcp_logger, :routes
 
@@ -26,7 +26,6 @@ module Sanford
       @worker_class    = args[:worker_class]
       @worker_params   = args[:worker_params] || {}
       @num_workers     = args[:num_workers]
-      @init_procs      = args[:init_procs]  || []
       @error_procs     = args[:error_procs] || []
       @template_source = args[:template_source]
       @logger          = args[:logger]


### PR DESCRIPTION
The goal here is that we keep all 3 of these "interface" gems in
sync implementation-wise as much as possible.  These are a bunch
of cleanups that I noticed while removing the ns-options dependency
from Qs.  I used Sanford for reference as it has already removed
its ns-options dependency (see PR 173).

Most of this stuff is relatively minor, but I want to highlight
two not-so-minor changes that are backwards incompatible:

* I chose to remove `init_procs` from the server data.  This is
  consistent with how Deas/Qs don't have this in their corresponding
  server/daemon datas.  The init procs are designed to be run once
  at server init time are run from the server's main Config.  They
  don't need to be passed around in the server data as nothing that
  receives the server data will need the init procs.
* I chose to remove the `dat_tcp_server` reader from the server
  instances.  This, again, matches how Qs does not expose its
  `worker_pool` on its daemon instances.  This is an implementation
  detail that we don't need to expose - plus this keeps the server
  api as simple as possible.

All the other changes are either style-related, consistent attr
order implementations and tests, or are updates to keep consistent
with Qs' implementation.  Most of these *should* have been done in
PR 173 but were missed.

See #173 for reference.

@jcredding ready for review.