### PR TITLE
get test suite passing in modern ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'pry', "~> 0.9.0"
-gem 'bson_ext'
+gem 'bson_ext', '~>1.7'

--- a/lib/sanford/error_handler.rb
+++ b/lib/sanford/error_handler.rb
@@ -45,13 +45,13 @@ module Sanford
     def response_from_exception(exception)
       if exception.kind_of?(Sanford::Protocol::BadMessageError) ||
          exception.kind_of?(Sanford::Protocol::Request::InvalidError)
-        build_response :bad_request, :message => exception.message
+        build_response 400, :message => exception.message # BAD REQUEST
       elsif exception.kind_of?(Sanford::NotFoundError)
-        build_response :not_found
+        build_response 404 # NOT FOUND
       elsif exception.kind_of?(Sanford::Protocol::TimeoutError)
-        build_response :timeout
+        build_response 408 # TIMEOUT
       else
-        build_response :error, :message => "An unexpected error occurred."
+        build_response 500, :message => "An unexpected error occurred." # ERROR
       end
     end
 

--- a/sanford.gemspec
+++ b/sanford.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("dat-tcp",          ["~> 0.8.0"])
-  gem.add_dependency("much-plugin",      ["~> 0.1.1"])
-  gem.add_dependency("sanford-protocol", ["~> 0.11.0"])
+  gem.add_dependency("dat-tcp",          ["~> 0.8.1"])
+  gem.add_dependency("much-plugin",      ["~> 0.2.0"])
+  gem.add_dependency("sanford-protocol", ["~> 0.12.0"])
 end

--- a/test/support/app_server.rb
+++ b/test/support/app_server.rb
@@ -10,13 +10,16 @@ LOGGER = Logger.new(ROOT_PATH.join('log/app_server.log').to_s)
 LOGGER.datetime_format = "" # turn off the datetime in the logs
 
 class AppERBEngine < Sanford::TemplateEngine
-  RenderScope = Struct.new(:view)
+  RenderScope = Class.new(Struct.new(:view)) do
+    def get_binding; binding; end
+  end
 
   def render(path, service_handler, locals)
     require 'erb'
     full_path = ROOT_PATH.join("test/support/#{path}.erb")
-    binding = RenderScope.new(service_handler).send(:binding)
-    ERB.new(File.read(full_path)).result(binding)
+
+    b = RenderScope.new(service_handler).get_binding
+    ERB.new(File.read(full_path)).result(b)
   end
 end
 

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -100,7 +100,7 @@ class Sanford::ErrorHandler
     subject{ @response }
 
     should "return a bad request response" do
-      exp = Sanford::Protocol::Response.new([:bad_request, @exception.message])
+      exp = Sanford::Protocol::Response.new([400, @exception.message])
       assert_equal exp, subject
     end
 
@@ -117,7 +117,7 @@ class Sanford::ErrorHandler
     subject{ @response }
 
     should "return a bad request response" do
-      exp = Sanford::Protocol::Response.new([:bad_request, @exception.message])
+      exp = Sanford::Protocol::Response.new([400, @exception.message])
       assert_equal exp, subject
     end
 
@@ -134,7 +134,7 @@ class Sanford::ErrorHandler
     subject{ @response }
 
     should "return a not found response" do
-      exp = Sanford::Protocol::Response.new(:not_found)
+      exp = Sanford::Protocol::Response.new(404)
       assert_equal exp, subject
     end
 
@@ -151,7 +151,7 @@ class Sanford::ErrorHandler
     subject{ @response }
 
     should "return a timeout response" do
-      exp = Sanford::Protocol::Response.new(:timeout)
+      exp = Sanford::Protocol::Response.new(408)
       assert_equal exp, subject
     end
 
@@ -168,7 +168,7 @@ class Sanford::ErrorHandler
     subject{ @response }
 
     should "return an error response" do
-      exp = Sanford::Protocol::Response.new([:error, "An unexpected error occurred."])
+      exp = Sanford::Protocol::Response.new([500, "An unexpected error occurred."])
       assert_equal exp, subject
     end
 
@@ -198,7 +198,7 @@ class Sanford::ErrorHandler
     end
 
     should "return an error response" do
-      exp = Sanford::Protocol::Response.new([:error, "An unexpected error occurred."])
+      exp = Sanford::Protocol::Response.new([500, "An unexpected error occurred."])
       assert_equal exp, @response
     end
 
@@ -240,15 +240,15 @@ class Sanford::ErrorHandler
   class RunWithSymbolFromErrorProcTests < RunSetupTests
     desc "with a response symbol returned from an error proc"
     setup do
-      @response_symbol = [:not_found, :bad_request, :error].sample
-      @error_proc_spies.sample.response = @response_symbol
+      @response_code = [400, 404, 500].sample
+      @error_proc_spies.sample.response = @response_code
 
       @response = @handler.run
     end
     subject{ @response }
 
     should "use the response symbol to build a response and return it" do
-      exp = Sanford::Protocol::Response.new(@response_symbol)
+      exp = Sanford::Protocol::Response.new(@response_code)
       assert_equal exp, subject
     end
 


### PR DESCRIPTION
This updates the gem dependencies to bring in the latest versions
(which also now work in modern ruby versions) and updates the test
suite to get things passing in modern ruby versions. This mostly
updating response handling to use response codes (as this is the
only way to build responses in the latest sanford-protocol).

In addition, I had to update the tests' AppServer and its ERB
handling.  Apparently, calling `send(:binding)` on an object no
longer returns a binding in the scope of the object.  So, I had
to hold Ruby's hand and go through the theatrics of setting up
a `get_binding` method on the RenderScope that calls binding
from said method.  Ok Ruby, I'll be super formal about it all.

@jcredding ready for review.