### PR TITLE
update the process to label more like Qs does

### DIFF
--- a/lib/sanford/process.rb
+++ b/lib/sanford/process.rb
@@ -10,8 +10,10 @@ module Sanford
     def initialize(server, options = nil)
       options ||= {}
       @server = server
+      @name   = "sanford: #{@server.process_label}"
       @logger = @server.logger
-      @pid_file = PIDFile.new(@server.pid_file)
+
+      @pid_file    = PIDFile.new(@server.pid_file)
       @restart_cmd = RestartCmd.new
 
       @server_ip   = @server.configured_ip
@@ -20,8 +22,6 @@ module Sanford
         ENV['SANFORD_SERVER_FD'].to_i
       end
       @listen_args = @server_fd ? [@server_fd] : [@server_ip, @server_port]
-
-      @name = "sanford-#{@server.name}-#{@server_ip}-#{@server_port}"
 
       @client_fds = ENV['SANFORD_CLIENT_FDS'].to_s.split(',').map(&:to_i)
 

--- a/lib/sanford/server.rb
+++ b/lib/sanford/server.rb
@@ -59,10 +59,6 @@ module Sanford
         })
       end
 
-      def name
-        @server_data.name
-      end
-
       def ip
         @dat_tcp_server.ip
       end
@@ -79,12 +75,20 @@ module Sanford
         @dat_tcp_server.client_file_descriptors
       end
 
+      def name
+        @server_data.name
+      end
+
       def configured_ip
         @server_data.ip
       end
 
       def configured_port
         @server_data.port
+      end
+
+      def process_label
+        @server_data.process_label
       end
 
       def pid_file

--- a/lib/sanford/server_data.rb
+++ b/lib/sanford/server_data.rb
@@ -12,7 +12,7 @@ module Sanford
     attr_reader :worker_class, :worker_params, :num_workers
     attr_reader :error_procs, :template_source, :logger, :router
     attr_reader :receives_keep_alive, :verbose_logging
-    attr_reader :debug, :dtcp_logger, :routes
+    attr_reader :debug, :dtcp_logger, :routes, :process_label
 
     def initialize(args = nil)
       args ||= {}
@@ -37,6 +37,12 @@ module Sanford
       @debug       = !ENV['SANFORD_DEBUG'].to_s.empty?
       @dtcp_logger = @logger if @debug
       @routes      = build_routes(args[:routes] || [])
+
+      @process_label = if (label = ENV['SANFORD_PROCESS_LABEL'].to_s).empty?
+        "#{@name}-#{@ip}-#{@port}"
+      else
+        label
+      end
     end
 
     def route_for(name)

--- a/test/system/server_tests.rb
+++ b/test/system/server_tests.rb
@@ -346,6 +346,24 @@ module Sanford::Server
 
   end
 
+  class WithEnvProcessLabelTests < SystemTests
+    desc "with a process label env var"
+    setup do
+      ENV['SANFORD_PROCESS_LABEL'] = Factory.string
+
+      @server = AppServer.new
+    end
+    teardown do
+      ENV.delete('SANFORD_PROCESS_LABEL')
+    end
+    subject{ @server }
+
+    should "set the daemons process label to the env var" do
+      assert_equal ENV['SANFORD_PROCESS_LABEL'], subject.process_label
+    end
+
+  end
+
   class TestClient
     attr_accessor :delay, :bytes
 

--- a/test/unit/process_tests.rb
+++ b/test/unit/process_tests.rb
@@ -53,10 +53,9 @@ class Sanford::Process
     end
 
     should "know its name, pid file and restart cmd" do
-      expected = "sanford-#{@server_spy.name}-" \
-                 "#{@server_spy.configured_ip}-#{@server_spy.configured_port}"
-      assert_equal expected, subject.name
-      assert_equal @pid_file_spy, subject.pid_file
+      exp = "sanford: #{@server_spy.process_label}"
+      assert_equal exp,              subject.name
+      assert_equal @pid_file_spy,    subject.pid_file
       assert_equal @restart_cmd_spy, subject.restart_cmd
     end
 
@@ -372,6 +371,7 @@ class Sanford::Process
     port Factory.integer
     pid_file Factory.file_path
 
+    attr_accessor :process_label
     attr_reader :listen_called, :start_called
     attr_reader :stop_called, :halt_called, :pause_called
     attr_reader :listen_args, :start_args
@@ -379,6 +379,9 @@ class Sanford::Process
 
     def initialize(*args)
       super
+
+      @process_label = Factory.string
+
       @listen_called = false
       @start_called = false
       @stop_called = false

--- a/test/unit/server_tests.rb
+++ b/test/unit/server_tests.rb
@@ -131,9 +131,8 @@ module Sanford::Server
     subject{ @server }
 
     should have_readers :server_data
-    should have_imeths :name, :ip, :port
-    should have_imeths :file_descriptor, :client_file_descriptors
-    should have_imeths :configured_ip, :configured_port
+    should have_imeths :ip, :port, :file_descriptor, :client_file_descriptors
+    should have_imeths :name, :configured_ip, :configured_port, :process_label
     should have_imeths :pid_file, :logger, :router, :template_source
     should have_imeths :listen, :start, :pause, :stop, :halt
     should have_imeths :paused?
@@ -188,6 +187,7 @@ module Sanford::Server
       assert_equal data.name,            subject.name
       assert_equal data.ip,              subject.configured_ip
       assert_equal data.port,            subject.configured_port
+      assert_equal data.process_label,   subject.process_label
       assert_equal data.pid_file,        subject.pid_file
       assert_equal data.logger,          subject.logger
       assert_equal data.router,          subject.router


### PR DESCRIPTION
This does a number of small tweaks to get Sanford setting its
process label like Qs does.  This label is slightly easier to read.
This also adds the ability to override the label with an ENV var.

The process label is now set by the server data, proxied by the
server where the process accesses and uses it.  The "sanford" str
is no longer part of the raw label - it is now added by the process.
This allows you to override the details of the label with the env
var while retaining the `sanford:` label prefix.

@jcredding ready for review.