### PR TITLE
update signal handling to use self-pipe; mimic Qs' implementation

### DIFF
--- a/lib/sanford/io_pipe.rb
+++ b/lib/sanford/io_pipe.rb
@@ -1,0 +1,40 @@
+module Sanford
+
+  class IOPipe
+
+    NULL = File.open('/dev/null', 'w')
+    NUMBER_OF_BYTES = 1
+
+    attr_reader :reader, :writer
+
+    def initialize
+      @reader = NULL
+      @writer = NULL
+    end
+
+    def setup
+      @reader, @writer = ::IO.pipe
+    end
+
+    def teardown
+      @reader.close unless @reader === NULL
+      @writer.close unless @writer === NULL
+      @reader = NULL
+      @writer = NULL
+    end
+
+    def read
+      @reader.read_nonblock(NUMBER_OF_BYTES)
+    end
+
+    def write(value)
+      @writer.write_nonblock(value[0, NUMBER_OF_BYTES])
+    end
+
+    def wait(timeout = nil)
+      !!::IO.select([@reader], nil, nil, timeout)
+    end
+
+  end
+
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -13,6 +13,8 @@ ROOT_PATH = Pathname.new(File.expand_path('../..', __FILE__))
 
 require 'test/support/factory'
 
+JOIN_SECONDS = 0.1
+
 # 1.8.7 backfills
 
 # Array#sample

--- a/test/unit/io_pipe_tests.rb
+++ b/test/unit/io_pipe_tests.rb
@@ -1,0 +1,84 @@
+require 'assert'
+require 'sanford/io_pipe'
+
+require 'thread'
+
+class Sanford::IOPipe
+
+  class UnitTests < Assert::Context
+    desc "Sanford::IOPipe"
+    setup do
+      # mimic how IO.select responds
+      @io_select_response    = Factory.boolean ? [[NULL], [], []] : nil
+      @io_select_called_with = nil
+      Assert.stub(IO, :select) do |*args|
+        @io_select_called_with = args
+        @io_select_response
+      end
+
+      @io_pipe = Sanford::IOPipe.new
+    end
+    subject{ @io_pipe }
+
+    should have_readers :reader, :writer
+    should have_imeths :setup, :teardown
+    should have_imeths :read, :write, :wait
+
+    should "default its reader and writer" do
+      assert_same NULL, subject.reader
+      assert_same NULL, subject.writer
+    end
+
+    should "change its reader/writer to an IO pipe when setup" do
+      subject.setup
+      assert_not_same NULL, subject.reader
+      assert_not_same NULL, subject.writer
+      assert_instance_of IO, subject.reader
+      assert_instance_of IO, subject.writer
+    end
+
+    should "close its reader/writer and set them to defaults when torn down" do
+      subject.setup
+      reader = subject.reader
+      writer = subject.writer
+
+      subject.teardown
+      assert_true reader.closed?
+      assert_true writer.closed?
+      assert_same NULL, subject.reader
+      assert_same NULL, subject.writer
+    end
+
+    should "be able to read/write values" do
+      subject.setup
+
+      value = Factory.string(NUMBER_OF_BYTES)
+      subject.write(value)
+      assert_equal value, subject.read
+    end
+
+    should "only read/write a fixed number of bytes" do
+      subject.setup
+
+      value = Factory.string
+      subject.write(value)
+      assert_equal value[0, NUMBER_OF_BYTES], subject.read
+    end
+
+    should "be able to wait until there is something to read" do
+      subject.setup
+
+      result = subject.wait
+      exp = [[subject.reader], nil, nil, nil]
+      assert_equal exp, @io_select_called_with
+      assert_equal !!@io_select_response, result
+
+      timeout = Factory.integer
+      subject.wait(timeout)
+      exp = [[subject.reader], nil, nil, timeout]
+      assert_equal exp, @io_select_called_with
+    end
+
+  end
+
+end


### PR DESCRIPTION
This updates Sanford's signal handling to avoid doing "unsafe"
things in trap handlers.  The idea is you want to put as little
logic into the traps as possible, both to make them responsive
and b/c Ruby in 2.0+ starts failing if it detects "unsafe" things
in traps.

Note: Ruby 2 *should* have been complaining about the previous
implementation b/c a mutex sync was happening in the traps. I'm
note sure why it wasn't (maybe it was a few layers deep and that
confused the interpreter?) but this removes that "unsafe" action
and replaces it with a self-pipe implementation.

Now the traps just write signals onto the self pipe while the main
thread polls the pipe for signals to process.  Any processing
happens in the main thread instead of the traps.

This also reworks the process tests to support this new scheme
and makes them more thorough (this is just a mimic of Qs' tests).

@jcredding thanks for talking me through this one.  And great job on Qs - its setup was fairly easy to mimic and is a big improvement.  Ready for review.