### PR TITLE
Update restart to work with ruby 1.9+

### DIFF
--- a/bench/report.rb
+++ b/bench/report.rb
@@ -1,3 +1,5 @@
+$LOAD_PATH.push(File.expand_path('../..', __FILE__))
+
 require 'benchmark'
 require 'bench/client'
 


### PR DESCRIPTION
This updates the `Process` restart to work with ruby 1.9+. In
newer versions of ruby, its now necessary to pass a list of file
descriptors to redirect so the child process can have access to
them when using `Kernel.exec`. This updates the `Process` logic
to check the current ruby version and if its ruby 1.9+ it will
use the new `Kernel.exec`, otherwise it will work as it did.

The `RestartCmd` now has a different `run` method depending on
which version of ruby is being used. For ruby 1.8.7, its `run`
method is mostly the same as it was before. It now takes a server
and handles setting the env variables. This is to make it
compatible with the ruby 1.9+ `run` method which needs a server to
build the env variables and to build the file descriptor redirects.
This also lets the `RestartCmd` encapsulate all of the logic needed
to restart the server. For ruby 1.9+, the `run` method takes a
server, builds the env variable hash and builds an exec options
hash. The options hash tells the `exec` to change the dir and
redirect the file descriptors so the child process can use them.

This also updates the bench script to work with ruby 1.9+. This
adds the root path to the load path since ruby doesn't do this
automatically anymore.

@kellyredding - Ready for review. This probably doesn't have to be done for qs since it doesn't use any file descriptors but I'm planning on updating its implementation to match as much as possible so they are consistent.