### PR TITLE
Catch dat-worker-pool shutdown errors and run error handler

### DIFF
--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -12,4 +12,11 @@ module Factory
     exception
   end
 
+  def self.protocol_response
+    Sanford::Protocol::Response.new(
+      [Factory.integer(999), Factory.text],
+      { Factory.string => Factory.string }
+    )
+  end
+
 end


### PR DESCRIPTION
This updates the connection handler to catch dat-worker-pool
shutdown errors and run its error handler. This allows the error
handlers to report that a request errored because the server is
being shutdown. The shutdown error is re-raised after it is caught
and reported on which forces the worker thread to exit.

The connection handler now rescues a `DatWorkerPool::ShutdownError`
and builds a `Sanford::ShutdownError` using the same message and
backtrace. The sanford shutdown error is passed to the error
handler which runs configured error procs for the shutdown error.
Sanford already always handles writing a response so when the
shutdown error is re-raised, the client still gets an error
response.

This also updates the error logging to handle if an exception
doesn't have a backtrace. Furthermore, this updates it to match
how we log errors in qs by logging each backtrace line separately.
This adds `[Sanford]` to the beginning of every line so backtrace
lines stay lined up. It also allows grepping for `[Sanford]` since
and seeing all of the log messages specific to sanford, including
all of the backtrace lines.

@kellyredding - Ready for review.