### PR TITLE
Catch non `StandardError` exceptions in `ConnectionHandler`

### DIFF
--- a/lib/sanford/connection_handler.rb
+++ b/lib/sanford/connection_handler.rb
@@ -51,7 +51,7 @@ module Sanford
         error.set_backtrace(exception.backtrace)
         self.handle_exception(error, @server_data, processed_service)
         raise exception
-      rescue StandardError => exception
+      rescue *Sanford::ErrorHandler::STANDARD_ERROR_CLASSES => exception
         self.handle_exception(exception, @server_data, processed_service)
       ensure
         self.write_response(processed_service)
@@ -62,7 +62,7 @@ module Sanford
     def write_response(processed_service)
       begin
         @connection.write_data processed_service.response.to_hash
-      rescue StandardError => exception
+      rescue *Sanford::ErrorHandler::STANDARD_ERROR_CLASSES => exception
         processed_service = self.handle_exception(
           exception,
           @server_data,

--- a/lib/sanford/error_handler.rb
+++ b/lib/sanford/error_handler.rb
@@ -1,8 +1,14 @@
+require 'dat-worker-pool/worker'
 require 'sanford-protocol'
 
 module Sanford
 
   class ErrorHandler
+
+    # these are standard error classes that we rescue and run through any
+    # configured error procs; use the same standard error classes that
+    # dat-worker-pool rescues
+    STANDARD_ERROR_CLASSES = DatWorkerPool::Worker::STANDARD_ERROR_CLASSES
 
     attr_reader :exception, :context, :error_procs
 
@@ -24,7 +30,7 @@ module Sanford
         result = nil
         begin
           result = error_proc.call(@exception, @context)
-        rescue StandardError => proc_exception
+        rescue *STANDARD_ERROR_CLASSES => proc_exception
           @exception = proc_exception
         end
         response ||= response_from_proc(result)

--- a/sanford.gemspec
+++ b/sanford.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency("assert", ["~> 2.16.1"])
 
-  gem.add_dependency("dat-tcp",          ["~> 0.8.1"])
+  gem.add_dependency("dat-tcp",          ["~> 0.8.2"])
   gem.add_dependency("much-plugin",      ["~> 0.2.0"])
   gem.add_dependency("sanford-protocol", ["~> 0.12.0"])
 end

--- a/test/support/factory.rb
+++ b/test/support/factory.rb
@@ -1,4 +1,5 @@
 require 'assert/factory'
+require 'sanford/error_handler'
 
 module Factory
   extend Assert::Factory
@@ -10,6 +11,10 @@ module Factory
     begin; raise(klass, message); rescue klass => exception; end
     exception.set_backtrace(nil) if Factory.boolean
     exception
+  end
+
+  def self.sanford_std_error(message = nil)
+    self.exception(Sanford::ErrorHandler::STANDARD_ERROR_CLASSES.sample, message)
   end
 
   def self.protocol_response

--- a/test/unit/connection_handler_tests.rb
+++ b/test/unit/connection_handler_tests.rb
@@ -86,7 +86,7 @@ class Sanford::ConnectionHandler
 
   class RunWithExceptionSetupTests < InitTests
     setup do
-      @route_exception = Factory.exception
+      @route_exception = Factory.sanford_std_error
       Assert.stub(@route, :run){ raise @route_exception }
       Assert.stub(Sanford::ErrorHandler, :new) do |*args|
         @error_handler_spy = ErrorHandlerSpy.new(*args)
@@ -265,7 +265,7 @@ class Sanford::ConnectionHandler
     def initialize(exception, context_hash)
       @passed_exception = exception
       @context_hash     = context_hash
-      @exception        = Factory.exception
+      @exception        = Factory.sanford_std_error
       @response         = Factory.protocol_response
       @run_called       = false
     end

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -9,7 +9,7 @@ class Sanford::ErrorHandler
   class UnitTests < Assert::Context
     desc "Sanford::ErrorHandler"
     setup do
-      @exception   = Factory.exception
+      @exception   = Factory.sanford_std_error
       @server_data = Sanford::ServerData.new
       @request     = Sanford::Protocol::Request.new(Factory.string, {
         Factory.string => Factory.string
@@ -160,7 +160,7 @@ class Sanford::ErrorHandler
   class RunWithGenericErrorTests < RunWithNoResponseFromErrorProcSetupTests
     desc "but with a generic error"
     setup do
-      @exception = Factory.exception
+      @exception = Factory.sanford_std_error
 
       @handler  = @handler_class.new(@exception, @context_hash)
       @response = @handler.run
@@ -178,7 +178,7 @@ class Sanford::ErrorHandler
     desc "and run with error procs that throw exceptions"
     setup do
       @proc_exceptions = @error_proc_spies.reverse.map do |spy|
-        exception = Factory.exception(RuntimeError, @error_proc_spies.index(spy).to_s)
+        exception = Factory.sanford_std_error(@error_proc_spies.index(spy).to_s)
         spy.raise_exception = exception
         exception
       end


### PR DESCRIPTION
This updates the `ConnectionHandler` and `ErrorHandler` to catch
non `StandardError` exceptions. This updates sanford to rescue the
same exceptions that dat-worker-pool workers will rescue. These are
exceptions that we want to run through the configured error procs
even though they don't inherit from `StandardError` because they
won't shutdown the worker thread but they do cause a service to
fail. This includes ruby's `Timeout::Error`, `LoadError` and
`NotImplementedError`.

This updates the `ConnectionHandler` to not only rescue
`StandardError` but instead use dat-worker-pool's standard error
classes. Just like all standard errors have been up to this point,
any of these errors will be passed to the error handler which will
run through the configured error procs.

The `ErrorHandler` also rescues dat-worker-pool's standard error
classes while it is running configured error procs. This is
intended to be consistent with the payload handler; we want to
rescue the same kind of errors that happen while trying to run an
error proc. This ensures we are consistent in our error handling
while processing a service request.

@kellyredding - Ready for review