### PR TITLE
update the error handler error context to fetch its data

### DIFF
--- a/lib/sanford/error_handler.rb
+++ b/lib/sanford/error_handler.rb
@@ -76,16 +76,16 @@ module Sanford
     attr_reader :request, :handler_class, :response
 
     def initialize(args)
-      @server_data   = args[:server_data]
-      @request       = args[:request]
-      @handler_class = args[:handler_class]
-      @response      = args[:response]
+      @server_data   = args.fetch(:server_data)
+      @request       = args.fetch(:request)
+      @handler_class = args.fetch(:handler_class)
+      @response      = args.fetch(:response)
     end
 
     def ==(other)
       if other.kind_of?(self.class)
-        self.server_data   == other.server_data &&
-        self.request       == other.request &&
+        self.server_data   == other.server_data   &&
+        self.request       == other.request       &&
         self.handler_class == other.handler_class &&
         self.response      == other.response
       else

--- a/test/unit/error_handler_tests.rb
+++ b/test/unit/error_handler_tests.rb
@@ -292,7 +292,12 @@ class Sanford::ErrorHandler
       exp = Sanford::ErrorContext.new(@context_hash)
       assert_equal exp, subject
 
-      exp = Sanford::ErrorContext.new({})
+      exp = Sanford::ErrorContext.new({
+        :server_data   => Sanford::ServerData.new,
+        :request       => Factory.string,
+        :handler_class => Factory.string,
+        :response      => Factory.string
+      })
       assert_not_equal exp, subject
     end
 


### PR DESCRIPTION
This is to enforce that if the context expects a value sanford
supplies it. This also closes a gap in our tests and tests that
sanford is creating the context as necessary.

This is similar to a change Deas did to its error handler context
in redding/deas#223.

@jcredding ready for review.