### PR TITLE
add `partial` method to handlers and template source/engine

### DIFF
--- a/lib/sanford/runner.rb
+++ b/lib/sanford/runner.rb
@@ -68,6 +68,10 @@ module Sanford
       self.data(self.template_source.render(path, self.handler, locals || {}))
     end
 
+    def partial(path, locals = nil)
+      self.data(self.template_source.partial(path, locals || {}))
+    end
+
   end
 
 end

--- a/lib/sanford/service_handler.rb
+++ b/lib/sanford/service_handler.rb
@@ -62,10 +62,11 @@ module Sanford
       def params;  @sanford_runner.params;  end
 
       # response
-      def status(*args); @sanford_runner.status(*args); end
-      def data(*args);   @sanford_runner.data(*args);   end
-      def halt(*args);   @sanford_runner.halt(*args);   end
-      def render(*args); @sanford_runner.render(*args); end
+      def status(*args);  @sanford_runner.status(*args);  end
+      def data(*args);    @sanford_runner.data(*args);    end
+      def halt(*args);    @sanford_runner.halt(*args);    end
+      def render(*args);  @sanford_runner.render(*args);  end
+      def partial(*args); @sanford_runner.partial(*args); end
 
     end
 

--- a/lib/sanford/template_engine.rb
+++ b/lib/sanford/template_engine.rb
@@ -17,6 +17,10 @@ module Sanford
       raise NotImplementedError
     end
 
+    def partial(name, locals)
+      raise NotImplementedError
+    end
+
     def ==(other_engine)
       if other_engine.kind_of?(TemplateEngine)
         self.source_path == other_engine.source_path &&
@@ -31,6 +35,10 @@ module Sanford
   class NullTemplateEngine < TemplateEngine
 
     def render(template_name, service_handler, locals)
+      self.partial(template_name, locals)
+    end
+
+    def partial(template_name, locals)
       paths = Dir.glob(self.source_path.join("#{template_name}*"))
       if paths.size > 1
         raise ArgumentError, "#{template_name.inspect} matches more than one " \

--- a/lib/sanford/template_source.rb
+++ b/lib/sanford/template_source.rb
@@ -41,6 +41,11 @@ module Sanford
       engine.render(template_name, service_handler, locals)
     end
 
+    def partial(template_name, locals)
+      engine = @engines[get_template_ext(template_name)]
+      engine.partial(template_name, locals)
+    end
+
     def ==(other_template_source)
       if other_template_source.kind_of?(TemplateSource)
         self.path    == other_template_source.path &&

--- a/test/support/app_server.rb
+++ b/test/support/app_server.rb
@@ -21,6 +21,14 @@ class AppERBEngine < Sanford::TemplateEngine
     b = RenderScope.new(service_handler).get_binding
     ERB.new(File.read(full_path)).result(b)
   end
+
+  def partial(path, locals)
+    require 'erb'
+    full_path = ROOT_PATH.join("test/support/#{path}.erb")
+
+    b = RenderScope.new(nil).get_binding
+    ERB.new(File.read(full_path)).result(b)
+  end
 end
 
 class AppServer
@@ -38,12 +46,13 @@ class AppServer
   router do
     service_handler_ns 'AppHandlers'
 
-    service 'echo',         'Echo'
-    service 'raise',        'Raise'
-    service 'bad_response', 'BadResponse'
-    service 'template',     'Template'
-    service 'halt',         'Halt'
-    service 'custom_error', 'CustomError'
+    service 'echo',             'Echo'
+    service 'raise',            'Raise'
+    service 'bad_response',     'BadResponse'
+    service 'render_template',  'RenderTemplate'
+    service 'partial_template', 'PartialTemplate'
+    service 'halt',             'Halt'
+    service 'custom_error',     'CustomError'
   end
 
   Sanford::TemplateSource.new(ROOT_PATH.join('test/support').to_s).tap do |s|
@@ -96,9 +105,15 @@ module AppHandlers
     def init!
       @message = params['message']
     end
-
+  end
+  class RenderTemplate < Template
     def run!
       render "template"
+    end
+  end
+  class PartialTemplate < Template
+    def run!
+      partial "template"
     end
   end
 

--- a/test/support/template.erb
+++ b/test/support/template.erb
@@ -1,1 +1,1 @@
-ERB Template Message: <%= view.message %>
+ERB Template Message: <%= view.nil? ? '' : view.message %>

--- a/test/system/server_tests.rb
+++ b/test/system/server_tests.rb
@@ -166,11 +166,11 @@ module Sanford::Server
 
   end
 
-  class TemplateTests < RunningAppServerTests
+  class RenderTemplateTests < RunningAppServerTests
     desc "calling a service that renders a template"
     setup do
       @message = Factory.text
-      @client.set_request('template', :message => @message)
+      @client.set_request('render_template', :message => @message)
       @response = @client.call
     end
 
@@ -178,6 +178,22 @@ module Sanford::Server
       assert_equal 200, subject.code
       assert_nil subject.status.message
       assert_equal "ERB Template Message: #{@message}\n", subject.data
+    end
+
+  end
+
+  class PartialTemplateTests < RunningAppServerTests
+    desc "calling a service that renders a partial template"
+    setup do
+      @message = Factory.text
+      @client.set_request('partial_template', :message => @message)
+      @response = @client.call
+    end
+
+    should "return a success response with the rendered data" do
+      assert_equal 200, subject.code
+      assert_nil subject.status.message
+      assert_equal "ERB Template Message: \n", subject.data
     end
 
   end

--- a/test/system/service_handler_tests.rb
+++ b/test/system/service_handler_tests.rb
@@ -57,11 +57,11 @@ module Sanford::ServiceHandler
 
   end
 
-  class TemplateHandlerTests < SystemTests
-    desc "AppHandlers::Template"
+  class RenderTemplateHandlerTests < SystemTests
+    desc "AppHandlers::RenderTemplate"
     setup do
       @params = { 'message' => Factory.text }
-      @runner = test_runner(AppHandlers::Template, {
+      @runner = test_runner(AppHandlers::RenderTemplate, {
         :params          => @params,
         :template_source => AppServer.config.template_source
       })
@@ -78,7 +78,36 @@ module Sanford::ServiceHandler
     should "return a 200 response and render the template when run" do
       response = @runner.run
       assert_equal 200, response.code
+
       exp = "ERB Template Message: #{@params['message']}\n"
+      assert_equal exp, response.data
+    end
+
+  end
+
+  class PartialTemplateHandlerTests < SystemTests
+    desc "AppHandlers::PartialTemplate"
+    setup do
+      @params = { 'message' => Factory.text }
+      @runner = test_runner(AppHandlers::PartialTemplate, {
+        :params          => @params,
+        :template_source => AppServer.config.template_source
+      })
+      @handler = @runner.handler
+    end
+    subject{ @handler }
+
+    should have_readers :message
+
+    should "know its message" do
+      assert_equal @params['message'], subject.message
+    end
+
+    should "return a 200 response and render the template when run" do
+      response = @runner.run
+      assert_equal 200, response.code
+
+      exp = "ERB Template Message: \n"
       assert_equal exp, response.data
     end
 

--- a/test/unit/service_handler_tests.rb
+++ b/test/unit/service_handler_tests.rb
@@ -255,6 +255,14 @@ module Sanford::ServiceHandler
       assert_equal exp_args, @meth_args
     end
 
+    should "call to the runner for its partial helper" do
+      capture_runner_meth_args_for(:partial)
+      exp_args = @args
+      subject.instance_eval{ partial(*exp_args) }
+
+      assert_equal exp_args, @meth_args
+    end
+
     private
 
     def stub_runner_with_something_for(meth)

--- a/test/unit/template_engine_tests.rb
+++ b/test/unit/template_engine_tests.rb
@@ -19,7 +19,7 @@ class Sanford::TemplateEngine
     subject{ @engine }
 
     should have_readers :source_path, :logger, :opts
-    should have_imeths :render
+    should have_imeths :render, :partial
 
     should "default its source path" do
       assert_equal Pathname.new(nil.to_s), subject.source_path
@@ -56,6 +56,12 @@ class Sanford::TemplateEngine
       end
     end
 
+    should "raise NotImplementedError on `partial`" do
+      assert_raises NotImplementedError do
+        subject.partial(@path, @locals)
+      end
+    end
+
   end
 
   class NullTemplateEngineTests < Assert::Context
@@ -69,10 +75,11 @@ class Sanford::TemplateEngine
       assert_kind_of Sanford::TemplateEngine, subject
     end
 
-    should "read and return the given path in its source path on `render" do
+    should "read and return the given path in its source path" do
       exists_file = ['test/support/template', 'test/support/template.erb'].sample
       exp = File.read(Dir.glob("#{subject.source_path.join(exists_file)}*").first)
       assert_equal exp, subject.render(exists_file, @service_handler, @locals)
+      assert_equal exp, subject.partial(exists_file, @locals)
     end
 
     should "complain if given a path that matches multiple files" do
@@ -80,12 +87,18 @@ class Sanford::TemplateEngine
       assert_raises ArgumentError do
         subject.render(conflict_file, @service_handler, @locals)
       end
+      assert_raises ArgumentError do
+        subject.partial(conflict_file, @locals)
+      end
     end
 
     should "complain if given a path that does not exist in its source path" do
       no_exists_file = '/does/not/exists'
       assert_raises ArgumentError do
         subject.render(no_exists_file, @service_handler, @locals)
+      end
+      assert_raises ArgumentError do
+        subject.partial(no_exists_file, @locals)
       end
     end
 


### PR DESCRIPTION
This is an alternate to the `render` method that doesn't pass the
service handler to the template as a local.  Use this to render
partial templates that only rely on locals.

This is also to try and line up the template source api with Deas'
template source api.  Libs that provide common rendering behavior
for both Deas and Sanford expect the template source api to be the
same so this makes that happen.

Specifically, this will allow adding common picker items data
rendering logic needed by Romo.  Option data can come both from
a Deas view handler or from a Deas view handler via a Sanford
service call.  In both cases, we want to render the picker items
data in a common way.  This way, no matter whether we are given a
Deas or a Sanford template source, we can call `partial` in our
Romo common logic to render a common partial template for the
picker items data.

@jcredding ready for review.